### PR TITLE
Add required dependency for Windows

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pyqt5-stubs
 flit
 pyudev
 git+https://github.com/Nitrokey/pynitrokey.git@nk3-updater#egg=pynitrokey
+pywin32==305; sys_platform == 'win32'


### PR DESCRIPTION
Execution on Windows crashes with missing `win32api` dependency.

```
Traceback (most recent call last):
  File "nitrokey-app2.py", line 5, in <module>
  File "nitropyapp\gui.py", line 1035, in main
  File "nitropyapp\gui.py", line 150, in __init__
  File "nitropyapp\windows_notification.py", line 14, in __init__
ModuleNotFoundError: No module named 'win32api'
```

This PR adds the `pywin32` dependency to fix this issue.