### PR TITLE
Upgrade pynitrokey dependency to 0.4.32

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pyqt5-stubs
 flit
 pyudev
-git+https://github.com/Nitrokey/pynitrokey.git@nk3-updater#egg=pynitrokey
+pynitrokey==0.4.32
 pywin32==305; sys_platform == 'win32'

--- a/nitropyapp/gui.py
+++ b/nitropyapp/gui.py
@@ -224,7 +224,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
                     self.device = device
                     uuid = self.device.uuid()
                     if uuid:
-                        print(f"{self.device.path}: {self.device.name} {self.device.uuid().value:X}")
+                        print(f"{self.device.path}: {self.device.name} {self.device.uuid()}")
                     else:
                         print(f"{self.device.path}: {self.device.name}")
                         print("no uuid")

--- a/nitropyapp/gui.py
+++ b/nitropyapp/gui.py
@@ -224,7 +224,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
                     self.device = device
                     uuid = self.device.uuid()
                     if uuid:
-                        print(f"{self.device.path}: {self.device.name} {self.device.uuid():X}")
+                        print(f"{self.device.path}: {self.device.name} {self.device.uuid().value:X}")
                     else:
                         print(f"{self.device.path}: {self.device.name}")
                         print("no uuid")

--- a/nitropyapp/nk3_button.py
+++ b/nitropyapp/nk3_button.py
@@ -28,7 +28,7 @@ class Nk3Button(QtWidgets.QWidget):
         self.update_nk3_btn = update_nk3_btn
         self.progressBarUpdate = progressBarUpdate
         #########needs to create button in the vertical navigation with the nitrokey type and serial number as text
-        self.btn_nk3 = QtWidgets.QPushButton(QIcon(":/images/icon/usb_new.png"),"Nitrokey 3:"f"{self.device.uuid()%10000}")
+        self.btn_nk3 = QtWidgets.QPushButton(QIcon(":/images/icon/usb_new.png"),"Nitrokey 3:"f"{self.device.uuid().value%10000}")
         self.btn_nk3.setFixedSize(184,40)
         self.btn_nk3.setIconSize(QSize(20, 20))
         self.btn_nk3.clicked.connect(lambda:self.nk3_btn_pressed())
@@ -44,8 +44,8 @@ class Nk3Button(QtWidgets.QWidget):
         self.widget_nk_btns.setLayout(self.layout_nk_btns)
         self.nitrokeys_window.setWidget(self.widget_nk_btns)
         # buttons get placed over the place holder
-        self.own_update_btn = QtWidgets.QPushButton("Update Nitrokey 3"f"{self.device.uuid()%10000}", self.nitrokey3_frame)
-        self.own_change_pin = QtWidgets.QPushButton("Change Nitrokey 3 PIN "f"{self.device.uuid()%10000}", self.nitrokey3_frame)
+        self.own_update_btn = QtWidgets.QPushButton("Update Nitrokey 3"f"{self.device.uuid().value%10000}", self.nitrokey3_frame)
+        self.own_change_pin = QtWidgets.QPushButton("Change Nitrokey 3 PIN "f"{self.device.uuid().value%10000}", self.nitrokey3_frame)
         self.own_update_btn.setGeometry(12,134,413,27)
         self.own_change_pin.setGeometry(12,166,413,27)
         self.buttonLayout_nk3.addWidget(self.own_update_btn)

--- a/nitropyapp/pynitrokey_for_gui.py
+++ b/nitropyapp/pynitrokey_for_gui.py
@@ -111,7 +111,7 @@ def list():
     for device in list_nk3():
             uuid = device.uuid()
             if uuid:
-                print(f"{device.path}: {device.name} {device.uuid():X}")
+                print(f"{device.path}: {device.name} {device.uuid().value:X}")
             else:
                 print(f"{device.path}: {device.name}")
 


### PR DESCRIPTION
This PR upgrade the `pynitrokey` dependency to version `0.4.32`.

It implements a workaround for the NK3 `Uuid` class.
In the past the `uuid()` method on NK3 returned `int`.
With the upgrade of the latest release it returns the `Uuid` class, which only has conversion to `str` implemented.
Opened Nitrokey/pynitrokey#315 to have a conversion method to `int`.
Workaround just calls the `value` attribute of `Uuid` directly.