### PR TITLE
Make isort format compatible with black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ PACKAGE_NAME=nitropyapp
 VENV=venv
 PYTHON=python3
 
-BLACK_FLAGS=-t py39
-ISORT_FLAGS=--py 39
-
 # setup environment
 init: update-venv
 
@@ -32,10 +29,10 @@ build:
 
 # code checks
 check-format:
-	$(PYTHON) -m black $(BLACK_FLAGS) --check $(PACKAGE_NAME)/
+	$(PYTHON) -m black --check $(PACKAGE_NAME)/
 
 check-import-sorting:
-	$(PYTHON) -m isort $(ISORT_FLAGS) --check-only $(PACKAGE_NAME)/
+	$(PYTHON) -m isort --check-only $(PACKAGE_NAME)/
 
 check-style:
 	$(PYTHON) -m flake8 $(PACKAGE_NAME)/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ Source = "https://github.com/Nitrokey/nitrokey-app2"
 
 [project.scripts]
 nitropyapp = "nitropyapp:main"
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,8 @@ Source = "https://github.com/Nitrokey/nitrokey-app2"
 nitropyapp = "nitropyapp:main"
 
 [tool.isort]
+py_version = "39"
 profile = "black"
+
+[tool.black]
+target-version = ["py39"]


### PR DESCRIPTION
This change will make `isort` work by the same rules as `black`. Otherwise they work by different rules, which leads to incompatible changes and a never passing CI.