### PR TITLE
Improve ci

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 30
+select = B,C,E,F,W,T4,B9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ nitrokeyapp = "nitrokeyapp:main"
 [tool.isort]
 py_version = "39"
 profile = "black"
+line_length = 80
 
 [tool.black]
 target-version = ["py39"]


### PR DESCRIPTION
- Set the same maximum line length for isort and flake8.
- Add same configuration for flake8 like on pynitrokey.