### PR TITLE
Fix missing icons

### DIFF
--- a/nitrokeyapp/__main__.py
+++ b/nitrokeyapp/__main__.py
@@ -2,6 +2,7 @@ import sys
 
 from PyQt5 import QtWidgets
 
+import nitrokeyapp.gui_resources  # noqa: F401
 from nitrokeyapp.gui import GUI, BackendThread
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 


### PR DESCRIPTION
This PR fixes a broken display of icons in the UI after recent refactor.

The issue was a missing import of `nitrokeyapp.gui_resources`.
It was prior imported to `nitrokeyapp.pin_dialog`.
Now it is imported to `nitrokeyapp.__main__`.
The import of another UI resource `import nitrokeyapp.ui.breeze_resources` from the same file was not moved, as it had no effect.