### PR TITLE
Rename nitropy-app2 to nitrokey-app2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Alternative Nitrokey Application - nitropy-app2
+# Alternative Nitrokey Application - nitrokey-app2
 
 Work in Progress !!
 
 ## To run on Linux:
 
 ```
-git clone https://github.com/Nitrokey/nitropy-app2.git
-cd nitropy-app2
+git clone https://github.com/Nitrokey/nitrokey-app2.git
+cd nitrokey-app2
 make init
 source venv/bin/activate
 python3 nitrokeyapp/__main__.py


### PR DESCRIPTION
I think you renamed this project but at least the README refers still to "nitropy-app2". I renamed it and now the instructions also work.