### PR TITLE
Build UI files with Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean: semi-clean
 build-ui: $(UI_DIR)
 	$(shell for file in $(UI_DIR)/*.ui; do pyuic5 $$file -o $$(sed 's/ui$$/py/' <<< $$file); done)
 
-build:
+build: build-ui
 	$(VENV)/bin/$(PYTHON) -m flit build
 
 # code checks

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PACKAGE_NAME=nitrokeyapp
 VENV=venv
 PYTHON=python3
+UI_DIR = nitrokeyapp/ui
 
 # setup environment
 init: update-venv
@@ -23,6 +24,9 @@ semi-clean:
 clean: semi-clean
 	rm -rf $(VENV)
 	rm -rf .mypy_cache
+
+build-ui: $(UI_DIR)
+	$(shell for file in $(UI_DIR)/*.ui; do pyuic5 $$file -o $$(sed 's/ui$$/py/' <<< $$file); done)
 
 build:
 	$(VENV)/bin/$(PYTHON) -m flit build


### PR DESCRIPTION
This PR introduces the Makefile target `build-ui`, which automatically creates the `.py` files from the `.ui` files in `nitrokeyapp/ui`.

Currently the change doesn't make it part of the `build` target, because if so the build command complains about untracked or deleted files in the source directory.

Potentially fixes #25 