### PR TITLE
Bump pynitrokey to version 0.4.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "pyqt5",
   "pyqt5-stubs",
   "pyudev",
-  "pynitrokey ==0.4.32",
+  "pynitrokey ==0.4.34",
   "pywin32 ==305; sys_platform =='win32'",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Upgrade dependency `pynitrokey` from version `0.4.32` to `0.4.34`.