### PR TITLE
Bump mypy to minimum version 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
   "flake8",
   "flit >= 3.2,<4",
   "isort",
-  "mypy >=0.900,<0.990",
+  "mypy >=1,<1.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
This updates the mypy dependency to version `>=1,<1.1`. This is in accordance with the configuration of the `pynitrokey` dependency.