### PR TITLE
Mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
   "flake8",
   "flit >= 3.2,<4",
   "isort",
-  "mypy >=0.900,<0.990",
+  "mypy >=1,<1.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,24 @@ line_length = 80
 
 [tool.black]
 target-version = ["py39"]
+
+[tool.mypy]
+show_error_codes = true
+python_version = "3.9"
+
+[[tool.mypy.overrides]]
+module = [
+  "nitrokeyapp.*",
+]
+disallow_untyped_defs = true
+
+# libraries without annotations
+[[tool.mypy.overrides]]
+module = [
+  "win32api.*",
+  "win32con.*",
+  "win32gui.*",
+  "pyudev.*",
+  "pynitrokey.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
This PR makes the following changes to the `mypy` configuration:
- Set Python version to `3.9`.
- Include checks for `nitrokeyapp` module and set `disallow_untyped_defs = true`.
- Ignore missing imports for `win32api`, `win32con`, `win32gui`, `pyudev`, `pynitrokey`.

Merge after #32.