### PR TITLE
Fix manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ The application can be compiled by executing:
 ```
 git clone https://github.com/Nitrokey/nitrokey-app2.git
 cd nitrokey-app2
-make
+make update-venv
 source venv/bin/activate
+make build
 python3 nitrokeyapp/__main__.py
 ```
 


### PR DESCRIPTION
The build target requires pyrrc5, so we first have to create and activate the virtual environment before running it.