### PR TITLE
Add __name__ check to __main__

### DIFF
--- a/nitrokeyapp/__main__.py
+++ b/nitrokeyapp/__main__.py
@@ -19,4 +19,5 @@ def main():
     app.exec()
 
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This patch fixes an issue where the main function would be executed twice.  This is necessary because the entry point is set to `nitrokeyapp.__main__:main`, so first the `__main__` module is imported and then `main` is called explicitly.

Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/61