### PR TITLE
Add abstraction for device tabs

### DIFF
--- a/nitrokeyapp/device_view.py
+++ b/nitrokeyapp/device_view.py
@@ -1,0 +1,21 @@
+from typing import Protocol
+
+from PyQt5.QtWidgets import QWidget
+
+from nitrokeyapp.device_data import DeviceData
+
+
+class DeviceView(Protocol):
+    @property
+    def title(self) -> str:
+        ...
+
+    @property
+    def widget(self) -> QWidget:
+        ...
+
+    def reset(self) -> None:
+        ...
+
+    def refresh(self, data: DeviceData) -> None:
+        ...

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -16,6 +16,7 @@ from PyQt5.QtCore import Qt, pyqtSlot
 
 from nitrokeyapp.about_dialog import AboutDialog
 from nitrokeyapp.device_data import DeviceData
+from nitrokeyapp.device_view import DeviceView
 from nitrokeyapp.information_box import InfoBox
 from nitrokeyapp.nk3_button import Nk3Button
 from nitrokeyapp.overview_tab import OverviewTab
@@ -92,6 +93,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
         self.about_dialog = AboutDialog(qt_app)
         self.overview_tab = OverviewTab(self.info_box, self)
+        self.views: list[DeviceView] = [self.overview_tab]
 
         # get widget objects
         # app wide widgets
@@ -107,8 +109,8 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         # set some props, initial enabled/visible, finally show()
         self.setAttribute(Qt.WA_DeleteOnClose)
 
-        self.tabs.addTab(self.overview_tab, "Overview")
-        self.tabs.setCurrentWidget(self.overview_tab)
+        for view in self.views:
+            self.tabs.addTab(view.widget, view.title)
         self.tabs.currentChanged.connect(self.slot_tab_changed)
 
         self.init_gui()
@@ -217,12 +219,12 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         """
         Should be called if the selected device or the selected tab is changed
         """
-        # TODO: only update selected tab
         if self.selected_device:
-            self.overview_tab.refresh(self.selected_device)
+            self.views[self.tabs.currentIndex()].refresh(self.selected_device)
             self.tabs.show()
         else:
-            self.overview_tab.reset()
+            for view in self.views:
+                view.reset()
             self.tabs.hide()
 
     def init_gui(self) -> None:

--- a/nitrokeyapp/overview_tab.py
+++ b/nitrokeyapp/overview_tab.py
@@ -22,6 +22,14 @@ class OverviewTab(QWidget):
 
         self.reset()
 
+    @property
+    def title(self) -> str:
+        return "Overview"
+
+    @property
+    def widget(self) -> QWidget:
+        return self
+
     def reset(self) -> None:
         self.data = None
         self.set_device_data("?", "?", "?")


### PR DESCRIPTION
This patch introduces the `DeviceView` protocol, an abstraction mainly intended for the device tabs but applicable for all widgets  that display device data.

Depends on:
- https://github.com/Nitrokey/nitrokey-app2/pull/81