### PR TITLE
Add log file

### DIFF
--- a/nitrokeyapp/__main__.py
+++ b/nitrokeyapp/__main__.py
@@ -7,7 +7,7 @@ from PyQt5 import QtWidgets
 
 import nitrokeyapp.ui.resources_rc  # noqa: F401
 from nitrokeyapp.gui import GUI
-from nitrokeyapp.logger import init_logging
+from nitrokeyapp.logger import init_logging, log_environment
 
 
 @contextmanager
@@ -24,10 +24,11 @@ def exception_handler(
 
 def main() -> None:
     app = QtWidgets.QApplication(sys.argv)
-    init_logging()
-    window = GUI(app)  # noqa: F841
-    with exception_handler(window.trigger_handle_exception.emit):
-        app.exec()
+    with init_logging() as log_file:
+        log_environment()
+        window = GUI(app, log_file)
+        with exception_handler(window.trigger_handle_exception.emit):
+            app.exec()
 
 
 if __name__ == "__main__":

--- a/nitrokeyapp/about_dialog.py
+++ b/nitrokeyapp/about_dialog.py
@@ -1,17 +1,26 @@
 from PyQt5 import QtWidgets
+from PyQt5.QtCore import pyqtSlot
 
 from nitrokeyapp import __version__
+from nitrokeyapp.logger import save_log
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 from nitrokeyapp.ui.aboutdialog import Ui_AboutDialog
 
 
 class AboutDialog(QtUtilsMixIn, QtWidgets.QDialog):
-    def __init__(self, qt_app: QtWidgets.QApplication) -> None:
+    def __init__(self, log_file: str, qt_app: QtWidgets.QApplication) -> None:
         QtWidgets.QDialog.__init__(self)
         QtUtilsMixIn.__init__(self)
+
+        self.log_file = log_file
 
         self.app = qt_app
         self.ui = Ui_AboutDialog()
         self.ui.setupUi(self)
         self.ui.ButtonOK.clicked.connect(self.close)
+        self.ui.buttonSaveLog.pressed.connect(self.save_log)
         self.ui.VersionLabel.setText(__version__)
+
+    @pyqtSlot()
+    def save_log(self) -> None:
+        save_log(self.log_file, self)

--- a/nitrokeyapp/error_dialog.py
+++ b/nitrokeyapp/error_dialog.py
@@ -2,17 +2,28 @@ from traceback import format_exception
 from types import TracebackType
 from typing import Optional, Type
 
-from PyQt5.QtWidgets import QDialog, QWidget
+from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QPushButton, QWidget
 
+from nitrokeyapp.logger import save_log
 from nitrokeyapp.ui.error_dialog import Ui_ErrorDialog
 
 
 class ErrorDialog(QDialog):
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(self, log_file: str, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
+
+        self.log_file = log_file
 
         self.ui = Ui_ErrorDialog()
         self.ui.setupUi(self)
+
+        self.button_save_log = QPushButton("Save Log File", self)
+        self.button_save_log.pressed.connect(self.save_log)
+
+        self.ui.buttonBox.addButton(
+            self.button_save_log, QDialogButtonBox.ButtonRole.ActionRole
+        )
 
     def set_exception(
         self,
@@ -22,3 +33,7 @@ class ErrorDialog(QDialog):
     ) -> None:
         lines = format_exception(ty, e, tb)
         self.ui.textEditDetails.setPlainText("".join(lines))
+
+    @pyqtSlot()
+    def save_log(self) -> None:
+        save_log(self.log_file, self)

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -77,7 +77,7 @@ class TouchDialog(QtWidgets.QMessageBox):
 class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
     trigger_handle_exception = pyqtSignal(object, BaseException, object)
 
-    def __init__(self, qt_app: QtWidgets.QApplication):
+    def __init__(self, qt_app: QtWidgets.QApplication, log_file: str):
         QtWidgets.QMainWindow.__init__(self)
         QtUtilsMixIn.__init__(self)
         # linux
@@ -101,6 +101,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         self.devices: list[DeviceData] = []
         self.device_buttons: list[Nk3Button] = []
         self.selected_device: Optional[DeviceData] = None
+        self.log_file = log_file
 
         self.trigger_handle_exception.connect(self.handle_exception)
 
@@ -114,7 +115,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             self.ui.label_information,
         )
 
-        self.about_dialog = AboutDialog(qt_app)
+        self.about_dialog = AboutDialog(log_file, qt_app)
         self.touch_dialog = TouchDialog(self)
         self.overview_tab = OverviewTab(self.info_box, self)
         self.views: list[DeviceView] = [self.overview_tab, SecretsTab(self)]
@@ -177,7 +178,9 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         e: BaseException,
         tb: Optional[TracebackType],
     ) -> None:
-        dialog = ErrorDialog(self)
+        logger.error("Unhandled exception", exc_info=(ty, e, tb))
+
+        dialog = ErrorDialog(self.log_file, self)
         dialog.set_exception(ty, e, tb)
         dialog.show()
 

--- a/nitrokeyapp/ui/aboutdialog.ui
+++ b/nitrokeyapp/ui/aboutdialog.ui
@@ -196,6 +196,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="buttonSaveLog">
+       <property name="text">
+        <string>Save Log File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -231,7 +238,6 @@
   <tabstop>label_3</tabstop>
   <tabstop>VersionLabel</tabstop>
   <tabstop>AboutLabel_2</tabstop>
-  <tabstop>ButtonOK</tabstop>
  </tabstops>
  <resources>
   <include location="resources.qrc"/>


### PR DESCRIPTION
This patch adds a log file for the app in /tmp.  Once the application is closed, the log file is deleted.  If an unexpected error occurs, the user has the option to save the log file so that it can be submitted to us.  The same option is available in the about dialog.

Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/74