### PR TITLE
secrets: Use QLineEdit for OTP

### DIFF
--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -159,7 +159,7 @@ class SecretsTab(QWidget):
 
     @pyqtSlot(OtpData)
     def otp_generated(self, data: OtpData) -> None:
-        self.ui.labelOtp.setText(data.otp)
+        self.ui.lineEditOtp.setText(data.otp)
 
         if data.validity:
             start, end = data.validity
@@ -172,7 +172,8 @@ class SecretsTab(QWidget):
 
         self.ui.pushButtonOtpGenerate.setVisible(data.validity is None)
         self.ui.progressBarOtpTimeout.setVisible(data.validity is not None)
-        self.ui.widgetOtp.show()
+        self.ui.labelOtp.show()
+        self.ui.lineEditOtp.show()
 
     def add_credential(self, credential: Credential) -> QListWidgetItem:
         icon = (
@@ -204,7 +205,7 @@ class SecretsTab(QWidget):
             self.ui.groupBoxOtp.show()
             self.ui.lineEditName.setText(credential.name)
             self.ui.checkBoxPinProtection.setChecked(credential.protected)
-            self.ui.labelOtpAlgorithm.setText(str(credential.otp))
+            self.ui.lineEditOtpAlgorithm.setText(str(credential.otp))
         else:
             self.ui.groupBoxOtp.hide()
         self.update_otp_generation(credential)
@@ -222,7 +223,8 @@ class SecretsTab(QWidget):
         self.otp_timeout = None
         self.otp_timer.stop()
         self.ui.progressBarOtpTimeout.hide()
-        self.ui.widgetOtp.hide()
+        self.ui.labelOtp.hide()
+        self.ui.lineEditOtp.hide()
 
         credential = self.get_current_credential()
         self.update_otp_generation(credential)

--- a/nitrokeyapp/ui/secrets_tab.ui
+++ b/nitrokeyapp/ui/secrets_tab.ui
@@ -159,8 +159,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>226</width>
-            <height>443</height>
+            <width>218</width>
+            <height>457</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -181,7 +181,10 @@
              <property name="title">
               <string>Metadata</string>
              </property>
-             <layout class="QFormLayout" name="formLayout_2">
+             <layout class="QFormLayout" name="formLayout_3">
+              <property name="horizontalSpacing">
+               <number>20</number>
+              </property>
               <item row="0" column="0">
                <widget class="QLabel" name="label">
                 <property name="text">
@@ -199,7 +202,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="1">
+              <item row="1" column="0" colspan="2">
                <widget class="QCheckBox" name="checkBoxPinProtection">
                 <property name="enabled">
                  <bool>false</bool>
@@ -212,9 +215,6 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QWidget" name="widget_6" native="true"/>
-              </item>
              </layout>
             </widget>
            </item>
@@ -223,78 +223,45 @@
              <property name="title">
               <string>One-Time Password</string>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_3">
-              <item>
-               <widget class="QWidget" name="widget_4" native="true">
-                <layout class="QHBoxLayout" name="horizontalLayout_3">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="label_2">
-                   <property name="text">
-                    <string>Algorithm</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelOtpAlgorithm">
-                   <property name="text">
-                    <string>?</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+             <layout class="QFormLayout" name="formLayout_2">
+              <property name="horizontalSpacing">
+               <number>20</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>Algorithm</string>
+                </property>
                </widget>
               </item>
-              <item>
-               <widget class="QWidget" name="widgetOtp" native="true">
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="label_3">
-                   <property name="text">
-                    <string>OTP</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelOtp">
-                   <property name="text">
-                    <string>?</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="lineEditOtpAlgorithm">
+                <property name="readOnly">
+                 <bool>true</bool>
+                </property>
                </widget>
               </item>
-              <item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="labelOtp">
+                <property name="text">
+                 <string>OTP</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLineEdit" name="lineEditOtp">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="readOnly">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0" colspan="2">
                <widget class="QProgressBar" name="progressBarOtpTimeout">
                 <property name="maximum">
                  <number>30</number>
@@ -313,42 +280,11 @@
                 </property>
                </widget>
               </item>
-              <item>
-               <widget class="QWidget" name="widget_5" native="true">
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <spacer name="horizontalSpacer">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="pushButtonOtpGenerate">
-                   <property name="text">
-                    <string>Generate</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+              <item row="3" column="0" colspan="2">
+               <widget class="QPushButton" name="pushButtonOtpGenerate">
+                <property name="text">
+                 <string>Generate</string>
+                </property>
                </widget>
               </item>
              </layout>


### PR DESCRIPTION
To make it possible to copy the generated OTP, we show it in a read-only QLineEdit instead of a QLabel.  For consistency, this patch uses a QLineEdit for the algorithm too.

Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/105

![otp-line-edit](https://github.com/Nitrokey/nitrokey-app2/assets/81762114/773902f2-6581-4f06-9f8c-d47006e9b083)

Ideally, the layouts of the two group boxes would use the same widths, but I’m not sure what’s the best way to achieve that.