### PR TITLE
secrets: Fix error tooltip when adding secret

### DIFF
--- a/nitrokeyapp/add_secret_dialog.py
+++ b/nitrokeyapp/add_secret_dialog.py
@@ -49,11 +49,13 @@ class AddSecretDialog(QDialog):
 
         button = self.ui.buttonBox.button(QDialogButtonBox.StandardButton.Ok)
         button.setEnabled(is_ok)
+
+        tooltip = ""
         if not is_ok:
             tooltip = "Please fix the following errors:"
             for error in errors:
                 tooltip += f"\n- {error}"
-            button.setToolTip(tooltip)
+        button.setToolTip(tooltip)
 
     def credential(self) -> Credential:
         name = self.ui.lineEditName.text()


### PR DESCRIPTION
Previously, the tooltip for the OK button in the Add Secret dialog was not reset if an input error has been resolved.  This patch fixes this oversight.

Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/113