### PR TITLE
secrets: Add touch prompt when deleting credential

### DIFF
--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -229,7 +229,8 @@ class DeleteCredentialJob(Job):
     def run(self) -> None:
         with self.data.open() as device:
             secrets = SecretsApp(device)
-            secrets.delete(self.credential.id)
+            with self.touch_prompt():
+                secrets.delete(self.credential.id)
             self.credential_deleted.emit(self.credential)
 
 


### PR DESCRIPTION
This patch adds a touch prompt when deleting a credential.  While a touch confirmation is not required at the moment, this is unintentional and will be changed in an upcoming firmware release.

See: https://github.com/Nitrokey/trussed-secrets-app/issues/92
Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/110