### PR TITLE
secrets: Use same width for labels

### DIFF
--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -68,6 +68,15 @@ class SecretsTab(QWidget):
         self.ui = Ui_SecretsTab()
         self.ui.setupUi(self)
 
+        labels = [
+            self.ui.labelName,
+            self.ui.labelAlgorithm,
+            self.ui.labelOtp,
+        ]
+        max_width = max([label.width() for label in labels])
+        for label in labels:
+            label.setMinimumWidth(max_width)
+
         self.ui.buttonAdd.pressed.connect(self.add_new_credential)
         self.ui.buttonDelete.pressed.connect(self.delete_credential)
         self.ui.buttonRefresh.pressed.connect(self.refresh_credential_list)

--- a/nitrokeyapp/ui/secrets_tab.ui
+++ b/nitrokeyapp/ui/secrets_tab.ui
@@ -186,7 +186,7 @@
                <number>20</number>
               </property>
               <item row="0" column="0">
-               <widget class="QLabel" name="label">
+               <widget class="QLabel" name="labelName">
                 <property name="text">
                  <string>Name</string>
                 </property>
@@ -228,7 +228,7 @@
                <number>20</number>
               </property>
               <item row="0" column="0">
-               <widget class="QLabel" name="label_2">
+               <widget class="QLabel" name="labelAlgorithm">
                 <property name="text">
                  <string>Algorithm</string>
                 </property>


### PR DESCRIPTION
This patch changes the minimum width for all form labels in the secrets tab to the maximum width of all labels.  This makes sure that the labels are properly aligned.

![1](https://github.com/Nitrokey/nitrokey-app2/assets/81762114/84647531-e1bd-4c06-939e-86dc8fd97b36)
