### PR TITLE
Windows device lresult error

### DIFF
--- a/nitrokeyapp/logger.py
+++ b/nitrokeyapp/logger.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 def init_logging() -> Generator[str, None, None]:
-    log_file = NamedTemporaryFile(prefix="nitrokey-app2.", suffix=".log")
+    log_file = NamedTemporaryFile(prefix="nitrokey-app2.", suffix=".log", delete=False)
     log_format = "%(relativeCreated)-8d %(levelname)6s %(name)10s %(message)s"
 
     try:

--- a/nitrokeyapp/windows_notification.py
+++ b/nitrokeyapp/windows_notification.py
@@ -43,7 +43,7 @@ class WindowsUSBNotifi:
         )
         win32gui.UpdateWindow(self.hwnd)
 
-    def onDeviceChange(self, hwnd: Any, msg: Any, wparam: int, lparam: Any) -> None:
+    def onDeviceChange(self, hwnd: Any, msg: Any, wparam: int, lparam: Any) -> int:
 
         import win32con
 
@@ -53,6 +53,7 @@ class WindowsUSBNotifi:
         if wparam == win32con.DBT_DEVICEREMOVECOMPLETE:
             logger.info("Windows: USB removed")
             self.remove_nk3()
+        return 0
 
     class DEV_BROADCAST_HDR(Structure):
         from ctypes import c_ulong, c_ushort

--- a/nitrokeyapp/windows_notification.py
+++ b/nitrokeyapp/windows_notification.py
@@ -7,8 +7,6 @@ logger = logging.getLogger(__name__)
 class WindowsUSBNotifi:
     from ctypes import Structure, c_ulong, c_ushort
 
-    DBT_DEVICEADDED = 0x8000
-    DBT_DEVICEREMOVED = 0x8004
     WORD = c_ushort
     DWORD = c_ulong
 
@@ -47,10 +45,12 @@ class WindowsUSBNotifi:
 
     def onDeviceChange(self, hwnd: Any, msg: Any, wparam: int, lparam: Any) -> None:
 
-        if wparam == self.DBT_DEVICEADDED:
+        import win32con
+
+        if wparam == win32con.DBT_DEVICEARRIVAL:
             logger.info("Windows: USB added")
             self.detect_nk3()
-        if wparam == self.DBT_DEVICEREMOVED:
+        if wparam == win32con.DBT_DEVICEREMOVECOMPLETE:
             logger.info("Windows: USB removed")
             self.remove_nk3()
 


### PR DESCRIPTION
Method `onDeviceChange` is a window procedure, which is called every time an event occurs.
This method handles the event types `DBT_DEVICEARRIVAL` and `DBT_DEVICEREMOVECOMPLETE`.
The [definition](https://learn.microsoft.com/en-us/windows/win32/learnwin32/writing-the-window-procedure) describes that such a function should return the data type `LRESULT`.
The `LRESULT` is [defined](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types) as `typedef LONG_PTR LRESULT;`.
Returning a value of `0` from this function seems to fix the issue.

Example for a window procedure [here](https://learn.microsoft.com/en-us/windows/win32/winmsg/using-window-procedures).

Fixes #127 