### PR TITLE
Bump pynitrokey, mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "pyqt5",
   "pyqt5-stubs",
   "pyudev",
-  "pynitrokey ==0.4.38",
+  "pynitrokey ==0.4.40",
   "pywin32 ==305; sys_platform =='win32'",
   "qt_material",
 ]
@@ -36,7 +36,7 @@ dev = [
   "flake8",
   "flit >= 3.2,<4",
   "isort",
-  "mypy >=1,<1.1",
+  "mypy >=1.4,<1.5",
   "pyinstaller ==5.9.0",
   "pyinstaller-versionfile ==2.1.1; sys_platform=='win32'",
 ]


### PR DESCRIPTION
This patch updates pynitrokey to 0.4.40 and mypy to 1.4.

pynitrokey 0.4.39 updated the sdsk dependency which fixes a build issue on some systems.  0.4.40 also fixed the “generator did not stop after throw” issue that has also been reported for the app.

mypy 1.4 fixes an occasional type checking error that had to be fixed by removing the cache.

Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/144