### PR TITLE
Fix missing UI resource files

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Build
         run: |
           . venv/bin/activate
-          flit build
+          make build
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-ui: $(UI_FILES)
 	$(foreach var,$(UI_FILES),pyuic5 --from-imports $(var) -o $(subst .ui,.py,$(var));)
 
 build: build-ui
-	$(VENV)/bin/$(PYTHON) -m flit build
+	$(VENV)/bin/$(PYTHON) -m flit build --no-use-vcs
 
 # code checks
 check-format:


### PR DESCRIPTION
This PR includes the dynamically created `*.py` files in `nitrokeyapp/ui` into the wheel and source archive uploaded to Pypi.

- The build command of *flit* only includes files checked in to the VCS. The default is changed with option `--no-use-vcs`.
- The *Pypi* pipeline was executing the command without the above option as well. This change makes it use the Makefile `build` target.

Fixes #162 