### PR TITLE
Add libglib2.0 for libgthread

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y binutils gcc libpcsclite-dev libusb-1.0-0 make swig
+          apt install -y binutils gcc libglib2.0-0 libpcsclite-dev libusb-1.0-0 make swig
       - name: Create virtual environment
         run: |
           python -m venv venv


### PR DESCRIPTION
This PR adds the `libglib2.0-0` package to the CD pipeline for Pypi. Change is necessary to prevent the pipeline from failing due to a missing dependency for compiling Qt5 UI files.