### PR TITLE
During the update process, the gui is busy

### DIFF
--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -239,6 +239,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         self.widget_show()
 
     def refresh(self) -> None:
+        self.overview_tab.busy_state_changed.connect(self.set_busy)
         """
         Should be called if the selected device or the selected tab is changed
         """
@@ -292,8 +293,13 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
     def set_busy(self, busy: bool) -> None:
         if busy:
             self.setCursor(QCursor(Qt.WaitCursor))
+            self.home_button.setEnabled(False)
+            self.tabs.setEnabled(False)
         else:
             self.unsetCursor()
+            self.home_button.setEnabled(True)
+            self.tabs.setEnabled(True)
+
         # TODO: setEnabled?
         # self.setEnabled(not busy)
 

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -243,6 +243,8 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         """
         Should be called if the selected device or the selected tab is changed
         """
+        self.overview_tab.busy_state_changed.connect(self.set_busy)
+
         if self.selected_device:
             self.widgetTab.hide()
             self.views[self.tabs.currentIndex()].refresh(self.selected_device)

--- a/nitrokeyapp/overview_tab.py
+++ b/nitrokeyapp/overview_tab.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from pynitrokey.nk3.admin_app import InitStatus
-from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QFileDialog, QWidget
 
 from nitrokeyapp.device_data import DeviceData
@@ -12,6 +12,8 @@ from nitrokeyapp.worker import Worker
 
 
 class OverviewTab(QtUtilsMixIn, QWidget):
+    busy_state_changed = pyqtSignal(bool)
+
     def __init__(self, info_box: InfoBox, parent: Optional[QWidget] = None) -> None:
         QWidget.__init__(self, parent)
         QtUtilsMixIn.__init__(self)
@@ -98,18 +100,26 @@ class OverviewTab(QtUtilsMixIn, QWidget):
 
         self.ui.pushButtonUpdate.setEnabled(enabled)
         self.ui.pushButtonUpdate.setToolTip(tooltip)
+        self.ui.more_options_btn.setEnabled(enabled)
+        self.ui.more_options_btn.setToolTip(tooltip)
 
     def update_btns_during_update(self, enabled: bool) -> None:
         tooltip = ""
         if enabled:
+            self.busy_state_changed.emit(False)
             self.ui.pushButtonUpdate.setEnabled(enabled)
             self.ui.pushButtonUpdate.setToolTip(tooltip)
+            self.ui.more_options_btn.setEnabled(enabled)
+            self.ui.more_options_btn.setToolTip(tooltip)
             self.ui.update_with_file_btn.setEnabled(enabled)
             self.ui.update_with_file_btn.setToolTip(tooltip)
         else:
             tooltip = "Update is already running. Please wait."
+            self.busy_state_changed.emit(True)
             self.ui.pushButtonUpdate.setEnabled(enabled)
             self.ui.pushButtonUpdate.setToolTip(tooltip)
+            self.ui.more_options_btn.setEnabled(enabled)
+            self.ui.more_options_btn.setToolTip(tooltip)
             self.ui.update_with_file_btn.setEnabled(enabled)
             self.ui.update_with_file_btn.setToolTip(tooltip)
 


### PR DESCRIPTION
During the update process, the gui is now in a waiting state. 
It is no longer possible to click on anything else in the app (except the help). 
The cursor also shows the waiting status.

Fix: #160 