### PR TITLE
Disable the use of keyrings for Poetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ update-venv:
 ifeq (, $(shell which poetry))
 $(error "No poetry in $(PATH)")
 endif
+	export PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring
 	poetry env use $(PYTHON)
 	poetry install --sync --without=deploy
 


### PR DESCRIPTION
This PR disables the use of keyrings for Poetry.

On certain systems *Poetry* produces unlock requests for the keyring, even though the access is not required.
This change configures the `Null` keyring, which makes the requests stop.
An unlocked keyring is not required for our environment.