### PR TITLE
Set required build system version to >=1.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.3.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
This PR sets the required version for the build system to `>=1.3.2`.

The background for this change is that *poetry-core* supports Python 3.11 only from version `1.3.2` on.
See related release notes [here](https://python-poetry.org/history/#poetry-core-132httpsgithubcompython-poetrypoetry-corereleasestag132).