### PR TITLE
Change PyPI repository url

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -57,6 +57,7 @@ jobs:
     needs: build
     env:
       POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+      POETRY_PYPI_URL: https://upload.pypi.org/legacy/
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -70,6 +71,6 @@ jobs:
           apt update
           apt install -y python3-poetry
       - name: Configure PyPI repository
-        run: poetry config repositories.pypi https://pypi.org/legacy/
+        run: poetry config repositories.pypi $POETRY_PYPI_URL
       - name: Publish release
         run: poetry publish -r pypi


### PR DESCRIPTION
This PR changes the PyPI repository URL.

In the past the repository URL `https://upload.pypi.org/legacy/` was used. During a change of the build system this was mistakenly changed to `https://pypi.org/legacy/`, which causes the PyPI publishing to fail.
This change also makes the URL being passed as environment variable of the workflow job.