### PR TITLE
Overview refactoring

### DIFF
--- a/nitrokeyapp/common_ui.py
+++ b/nitrokeyapp/common_ui.py
@@ -18,9 +18,3 @@ class CommonUi:
         self.info = InfoUi()
         self.progress = ProgressUi()
         self.prompt = PromptUi()
-
-    # def __init__(self, parent: QObject) -> None:
-    #     self.touch = TouchUi(parent)
-    #     self.info = InfoUi(parent)
-    #     self.progress = ProgressUi(parent)
-    #     self.prompt = PromptUi(parent)

--- a/nitrokeyapp/common_ui.py
+++ b/nitrokeyapp/common_ui.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+from nitrokeyapp.information_box import InfoUi
+from nitrokeyapp.progress_box import ProgressUi
+from nitrokeyapp.prompt_box import PromptUi
+from nitrokeyapp.touch import TouchUi
+
+
+@dataclass
+class CommonUi:
+    touch: TouchUi
+    info: InfoUi
+    progress: ProgressUi
+    prompt: PromptUi
+
+    def __init__(self) -> None:
+        self.touch = TouchUi()
+        self.info = InfoUi()
+        self.progress = ProgressUi()
+        self.prompt = PromptUi()
+
+    # def __init__(self, parent: QObject) -> None:
+    #     self.touch = TouchUi(parent)
+    #     self.info = InfoUi(parent)
+    #     self.progress = ProgressUi(parent)
+    #     self.prompt = PromptUi(parent)

--- a/nitrokeyapp/device_data.py
+++ b/nitrokeyapp/device_data.py
@@ -1,14 +1,9 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from pynitrokey.nk3 import Nitrokey3Device
 
-from nitrokeyapp.information_box import InfoBox
-from nitrokeyapp.update import Nk3Context
-
-# TODO: This fixes a circular dependency, but should be avoided if possible
-if TYPE_CHECKING:
-    from nitrokeyapp.overview_tab import OverviewTab
+from nitrokeyapp.update import Nk3Context, UpdateGUI
 
 logger = logging.getLogger(__name__)
 
@@ -39,18 +34,16 @@ class DeviceData:
 
     def update(
         self,
-        overview_tab: "OverviewTab",
-        info_frame: InfoBox,
+        ui: UpdateGUI,
         image: Optional[str] = None,
-    ) -> None:
+    ) -> bool:
         self.updating = True
-        overview_tab.update_btns_during_update(False)
         try:
-            Nk3Context(self.path).update(overview_tab, info_frame, image)
-            logger.info("Successfully updated the Nitrokey 3")
-            info_frame.set_status("Successfully updated the Nitrokey 3.")
+            Nk3Context(self.path).update(ui, image)
+            logger.info("Nitrokey 3 successfully updated")
+            self.updating = False
+            return True
         except Exception as e:
-            logger.info(f"Failed to update Nitrokey 3 {e}")
-            info_frame.set_status("Failed to update Nitrokey 3.")
-        self.updating = False
-        overview_tab.update_btns_during_update(True)
+            logger.info(f"Nitrokey 3 failed to update - {e}")
+            self.updating = False
+            return False

--- a/nitrokeyapp/device_manager.py
+++ b/nitrokeyapp/device_manager.py
@@ -1,10 +1,5 @@
 import logging
-from typing import List, Optional
-
-from pynitrokey import nk3
-from pynitrokey.nk3 import Nitrokey3Base, Nitrokey3Device
-from pynitrokey.nk3.admin_app import Status
-from pynitrokey.nk3.utils import Uuid, Version
+from typing import List
 
 from nitrokeyapp.device_data import DeviceData
 

--- a/nitrokeyapp/device_manager.py
+++ b/nitrokeyapp/device_manager.py
@@ -1,0 +1,68 @@
+import logging
+from typing import List, Optional
+
+from pynitrokey import nk3
+from pynitrokey.nk3 import Nitrokey3Base, Nitrokey3Device
+from pynitrokey.nk3.admin_app import Status
+from pynitrokey.nk3.utils import Uuid, Version
+
+from nitrokeyapp.device_data import DeviceData
+
+logger = logging.getLogger(__name__)
+
+
+def match(lhs: DeviceData, rhs: DeviceData) -> bool:
+    if lhs.path == rhs.path:
+        if lhs.is_bootloader and rhs.is_bootloader:
+            return True
+        if lhs.uuid == rhs.uuid:
+            return True
+    return False
+
+
+class DeviceManager:
+    def __init__(self) -> None:
+        self._devices: List[DeviceData] = []
+
+    def count(self) -> int:
+        return len(self._devices)
+
+    def add(self) -> List[DeviceData]:
+        try:
+            all_devs = DeviceData.list()
+        except Exception as e:
+            logger.error(f"failed listing nk3 devices: {e}")
+            return []
+
+        new_devices = []
+        for candidate in all_devs:
+            res = list(filter(lambda x: match(x, candidate), self._devices))
+            if len(res) > 0:
+                org_dev = res[0]
+                # keep the most recent `path` + `_device`
+                org_dev.path = candidate.path
+                org_dev._device = candidate._device
+                continue
+            self._devices.append(candidate)
+            new_devices.append(candidate)
+
+        return new_devices
+
+    def remove(self) -> List[DeviceData]:
+        try:
+            all_devs = DeviceData.list()
+        except Exception as e:
+            logger.error(f"failed listing nk3 devices: {e}")
+            return []
+
+        out = []
+        for dev in self._devices:
+            res = list(filter(lambda x: match(x, dev), all_devs))
+            if len(res) == 0:
+                self._devices.remove(dev)
+                out.append(dev)
+
+        return out
+
+    def update(self) -> None:
+        pass

--- a/nitrokeyapp/device_view.py
+++ b/nitrokeyapp/device_view.py
@@ -2,11 +2,16 @@ from typing import Optional, Protocol
 
 from PySide6.QtWidgets import QWidget
 
+from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
 from nitrokeyapp.worker import Worker
 
 
 class DeviceView(Protocol):
+    @property
+    def common_ui(self) -> CommonUi:
+        ...
+
     @property
     def title(self) -> str:
         ...

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -152,7 +152,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         device_count = self.device_manager.count()
         if device_count == 0:
             self.l_insert_nitrokey.show()
-        self.overview_tab.set_update_enabled(device_count == 1)
+        self.overview_tab.set_update_enabled(device_count <= 1)
 
     def detect_added_devices(self) -> None:
         devs = self.device_manager.add()
@@ -167,7 +167,8 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
         # add as nk3 device
         logger.info(f"nk3 connected: {devs}")
-        self.info_box.set_status(f"Nitrokey 3 added: {devs}")
+        desc = ", ".join(str(dev.uuid) for dev in devs)
+        self.info_box.set_status(f"Nitrokey 3 added: {desc}")
         for dev in devs:
             self.add_device(dev)
 
@@ -177,7 +178,8 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             logger.info("failed removing device")
             return
 
-        self.info_box.set_status(f"Nitrokey 3 removed: {devs}")
+        desc = ", ".join(str(dev.uuid) for dev in devs)
+        self.info_box.set_status(f"Nitrokey 3 removed: {desc}")
         logger.info(f"nk3 disconnected: {devs}")
         for dev in devs:
             self.remove_device(dev)

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -156,6 +156,11 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
     def detect_added_devices(self) -> None:
         devs = self.device_manager.add()
+
+        # show device as the connection might been updated
+        if len(devs) == 0 and self.selected_device:
+            self.show_device(self.selected_device)
+
         if not devs:
             logger.info("failed adding device")
             return
@@ -187,8 +192,8 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
         if not self.selected_device:
             self.selected_device = data
+
         self.l_insert_nitrokey.hide()
-        self.show_device(self.selected_device)
 
     def remove_device(self, data: DeviceData) -> None:
         self.toggle_update_btn()
@@ -260,8 +265,9 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         self.show_navigation()
         self.welcome_widget.hide()
 
+        # enforce refreshing the current view
         view = self.views[self.tabs.currentIndex()]
-        view.refresh(data)
+        view.refresh(data, force=True)
 
     def hide_device(self) -> None:
         self.selected_device = None

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -103,6 +103,9 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
                 view.common_ui.info.info.connect(self.info_box.set_status)
                 view.common_ui.info.error.connect(self.info_box.set_error_status)
+                view.common_ui.info.pin_cached.connect(self.info_box.set_pin_icon)
+                view.common_ui.info.pin_cleared.connect(self.info_box.unset_pin_icon)
+                self.info_box.pin_pressed.connect(view.common_ui.info.pin_pressed)
 
                 view.common_ui.prompt.confirm.connect(self.prompt_box.confirm)
                 self.prompt_box.confirmed.connect(view.common_ui.prompt.confirmed)

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -7,10 +7,6 @@ from typing import Optional, Type
 if platform.system() == "Linux":
     import pyudev
 
-# Nitrokey 3
-from pynitrokey.nk3 import Nitrokey3Device
-
-# pyqt5
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import QCursor

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -170,7 +170,10 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
         # add as nk3 device
         logger.info(f"nk3 connected: {devs}")
-        desc = ", ".join(str(dev.uuid) for dev in devs)
+        desc = ", ".join(
+            (str(dev.uuid) if not dev.is_bootloader else "NK3 (BL)") for dev in devs
+        )
+
         self.info_box.set_status(f"Nitrokey 3 added: {desc}")
         for dev in devs:
             self.add_device(dev)
@@ -181,7 +184,9 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             logger.info("failed removing device")
             return
 
-        desc = ", ".join(str(dev.uuid) for dev in devs)
+        desc = ", ".join(
+            (str(dev.uuid) if not dev.is_bootloader else "NK3 (BL)") for dev in devs
+        )
         self.info_box.set_status(f"Nitrokey 3 removed: {desc}")
         logger.info(f"nk3 disconnected: {devs}")
         for dev in devs:

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -200,13 +200,17 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             self.selected_device = None
             self.hide_device()
 
+        def remove_button(btn: Nk3Button) -> None:
+            self.ui.nitrokeyButtonsLayout.removeWidget(button)
+            self.device_buttons.remove(button)
+            button.destroy()
+
         for button in self.device_buttons:
-            if button.data.uuid == data.uuid or (
-                data.is_bootloader and button.data.path == data.path
-            ):
-                self.ui.nitrokeyButtonsLayout.removeWidget(button)
-                self.device_buttons.remove(button)
-                button.destroy()
+            if button.data.is_bootloader:
+                if button.data.path == data.path:
+                    remove_button(button)
+            elif button.data.uuid == data.uuid:
+                remove_button(button)
 
         if self.device_manager.count() == 0:
             self.l_insert_nitrokey.show()

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -246,6 +246,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             btn.unfold()
 
         self.ui.vertical_navigation.setMinimumWidth(200)
+        self.ui.vertical_navigation.setMaximumWidth(200)
         self.ui.btn_dial_help.show()
 
         self.ui.main_logo.setMaximumWidth(120)

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -248,6 +248,11 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
     def show_device(self, data: DeviceData) -> None:
         self.selected_device = data
+        for btn in self.device_buttons:
+            if btn.data == data:
+                btn.setChecked(True)
+            else:
+                btn.setChecked(False)
 
         self.info_box.set_device(data.name)
         self.tabs.show()

--- a/nitrokeyapp/information_box.py
+++ b/nitrokeyapp/information_box.py
@@ -13,48 +13,8 @@ class InfoUi(QObject):
     pin_cached = Signal(bool)
     pin_pressed = Signal()
 
-    # def __init__(self, parent: QObject) -> None:
-    #    #super().__init__(parent)
-    #    super().__init__()
-
-    # self.info_box = info_box
-
     def __init__(self) -> None:
         super().__init__()
-
-    def connect_ui(self, info_box: "InfoBox") -> None:
-        self.error.connect(info_box.set_error_status)
-        self.info.connect(info_box.set_status)
-        self.pin_cached.connect(info_box.set_pin_icon)
-        self.pin_pressed.connect(info_box.pin_icon.pressed)
-
-    def connect_actions(
-        self,
-        error: Optional[Callable[[str], None]],
-        info: Optional[Callable[[str], None]],
-    ) -> "InfoUiConnection":
-        con = InfoUiConnection(self)
-        if error:
-            con.error = self.error.connect(error)
-        if info:
-            con.info = self.info.connect(info)
-        return con
-
-
-@dataclass
-class InfoUiConnection:
-    info_ui: InfoUi
-    error: Optional[QMetaObject.Connection] = None
-    info: Optional[QMetaObject.Connection] = None
-
-    def disconnect_actions(self) -> None:
-        if self.error:
-            self.info_ui.error.disconnect()
-            self.start = None
-        if self.info:
-            self.info_ui.info.disconnect()
-            self.info = None
-
 
 class InfoBox(QObject):
     def __init__(

--- a/nitrokeyapp/information_box.py
+++ b/nitrokeyapp/information_box.py
@@ -1,9 +1,59 @@
-from typing import Optional
+from dataclasses import dataclass
+from typing import Callable, Optional
 
 from PySide6 import QtCore, QtWidgets
-from PySide6.QtCore import QObject, Slot
+from PySide6.QtCore import QMetaObject, QObject, Signal, Slot
 
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
+
+
+class InfoUi(QObject):
+    error = Signal(str)
+    info = Signal(str)
+    pin_cached = Signal(bool)
+    pin_pressed = Signal()
+
+    # def __init__(self, parent: QObject) -> None:
+    #    #super().__init__(parent)
+    #    super().__init__()
+
+    # self.info_box = info_box
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def connect_ui(self, info_box: "InfoBox") -> None:
+        self.error.connect(info_box.set_error_status)
+        self.info.connect(info_box.set_status)
+        self.pin_cached.connect(info_box.set_pin_icon)
+        self.pin_pressed.connect(info_box.pin_icon.pressed)
+
+    def connect_actions(
+        self,
+        error: Optional[Callable[[str], None]],
+        info: Optional[Callable[[str], None]],
+    ) -> "InfoUiConnection":
+        con = InfoUiConnection(self)
+        if error:
+            con.error = self.error.connect(error)
+        if info:
+            con.info = self.info.connect(info)
+        return con
+
+
+@dataclass
+class InfoUiConnection:
+    info_ui: InfoUi
+    error: Optional[QMetaObject.Connection] = None
+    info: Optional[QMetaObject.Connection] = None
+
+    def disconnect_actions(self) -> None:
+        if self.error:
+            self.info_ui.error.disconnect()
+            self.start = None
+        if self.info:
+            self.info_ui.info.disconnect()
+            self.info = None
 
 
 class InfoBox(QObject):
@@ -20,6 +70,7 @@ class InfoBox(QObject):
         self.information_frame.show()
 
         self.status = status
+        self.status.hide()
         self.device = device
 
         self.icon = icon
@@ -32,6 +83,9 @@ class InfoBox(QObject):
         )
         self.set_pin_icon(False)
         self.pin_icon.hide()
+
+        # self.send_status.connect(lambda s: self.set_status(s))
+        # self.send_error_status.connect(self.set_error_status)
 
         # self.information_frame.setStyleSheet("background-color:#666666; border: 0;");
 

--- a/nitrokeyapp/information_box.py
+++ b/nitrokeyapp/information_box.py
@@ -1,8 +1,7 @@
-from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 from PySide6 import QtCore, QtWidgets
-from PySide6.QtCore import QMetaObject, QObject, Signal, Slot
+from PySide6.QtCore import QObject, Signal, Slot
 
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 
@@ -15,6 +14,7 @@ class InfoUi(QObject):
 
     def __init__(self) -> None:
         super().__init__()
+
 
 class InfoBox(QObject):
     def __init__(

--- a/nitrokeyapp/information_box.py
+++ b/nitrokeyapp/information_box.py
@@ -9,7 +9,8 @@ from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 class InfoUi(QObject):
     error = Signal(str)
     info = Signal(str)
-    pin_cached = Signal(bool)
+    pin_cached = Signal()
+    pin_cleared = Signal()
     pin_pressed = Signal()
 
     def __init__(self) -> None:
@@ -17,6 +18,8 @@ class InfoUi(QObject):
 
 
 class InfoBox(QObject):
+    pin_pressed = Signal()
+
     def __init__(
         self,
         information_frame: QtWidgets.QWidget,
@@ -43,6 +46,7 @@ class InfoBox(QObject):
         )
         self.set_pin_icon(False)
         self.pin_icon.hide()
+        self.pin_icon.clicked.connect(self.pin_pressed)
 
         # self.send_status.connect(lambda s: self.set_status(s))
         # self.send_error_status.connect(self.set_error_status)
@@ -106,7 +110,11 @@ class InfoBox(QObject):
         self.hide_status()
         self.pin_icon.hide()
 
-    @Slot(bool)
+    @Slot()
+    def unset_pin_icon(self) -> None:
+        self.set_pin_icon(False)
+
+    @Slot()
     def set_pin_icon(self, pin_cached: bool = True) -> None:
         if pin_cached:
             self.pin_icon.setIcon(QtUtilsMixIn.get_qicon("dialpad.svg"))

--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -67,6 +67,10 @@ class Nk3Button(QtWidgets.QPushButton):
 
     def fold(self) -> None:
         self.setText("")
+        self.setMinimumWidth(58)
+        self.setMaximumWidth(58)
 
     def unfold(self) -> None:
         self.setText(self.data.name)
+        self.setMinimumWidth(178)
+        self.setMaximumWidth(178)

--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -24,6 +24,8 @@ class Nk3Button(QtWidgets.QPushButton):
             apply_stylesheet(self, theme=get_theme_path())
 
         self.setCheckable(True)
+        self.setDefault(False)
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
 
         self.effect = QtWidgets.QGraphicsColorizeEffect(self)
         self.effect.setColor(QtGui.QColor(115, 215, 125))

--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from PySide6 import QtCore, QtGui, QtWidgets
 from qt_material import apply_stylesheet
 
@@ -11,13 +13,10 @@ class Nk3Button(QtWidgets.QPushButton):
         self,
         data: DeviceData,
     ) -> None:
-        super().__init__(
-            QtUtilsMixIn.get_qicon("nitrokey.svg"),
-            "Nitrokey 3: " f"{data.uuid_prefix}",
-        )
+        super().__init__(QtUtilsMixIn.get_qicon("nitrokey.svg"), data.name)
 
-        print("CREATING BUTTON with data: ", data)
         self.data = data
+        self.bootloader_data: Optional[DeviceData] = None
 
         # needs to create button in the vertical navigation with the nitrokey type and serial number as text
         # set material stylesheet if no system theme is set
@@ -66,4 +65,4 @@ class Nk3Button(QtWidgets.QPushButton):
         self.setText("")
 
     def unfold(self) -> None:
-        self.setText("Nitrokey 3: " f"{str(self.data.uuid)[:5]}")
+        self.setText(self.data.name)

--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -15,7 +15,10 @@ class Nk3Button(QtWidgets.QPushButton):
             QtUtilsMixIn.get_qicon("nitrokey.svg"),
             "Nitrokey 3: " f"{data.uuid_prefix}",
         )
+
+        print("CREATING BUTTON with data: ", data)
         self.data = data
+
         # needs to create button in the vertical navigation with the nitrokey type and serial number as text
         # set material stylesheet if no system theme is set
         if not self.style().objectName() or self.style().objectName() == "fusion":

--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -23,6 +23,8 @@ class Nk3Button(QtWidgets.QPushButton):
         if not self.style().objectName() or self.style().objectName() == "fusion":
             apply_stylesheet(self, theme=get_theme_path())
 
+        self.setCheckable(True)
+
         self.effect = QtWidgets.QGraphicsColorizeEffect(self)
         self.effect.setColor(QtGui.QColor(115, 215, 125))
         self.effect.setStrength(0)

--- a/nitrokeyapp/overview_tab/__init__.py
+++ b/nitrokeyapp/overview_tab/__init__.py
@@ -103,6 +103,8 @@ class OverviewTab(QtUtilsMixIn, QWidget):
                 self.ui.nk3_lineedit_init_status.hide()
             else:
                 self.status_error(InitStatus(data.status.init_status))
+                self.ui.label_init_status.show()
+                self.ui.nk3_lineedit_init_status.show()
 
     def set_device_data(
         self, path: str, uuid: str, version: str, variant: str, init_status: str

--- a/nitrokeyapp/overview_tab/__init__.py
+++ b/nitrokeyapp/overview_tab/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from pynitrokey.nk3.admin_app import InitStatus
@@ -10,6 +11,8 @@ from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 from nitrokeyapp.worker import Worker
 
 from .worker import OverviewWorker
+
+logger = logging.getLogger(__name__)
 
 
 class OverviewTab(QtUtilsMixIn, QWidget):
@@ -66,8 +69,8 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         self.data = None
         self.set_device_data("?", "?", "?", "?", "?")
 
-    def refresh(self, data: DeviceData) -> None:
-        if data == self.data:
+    def refresh(self, data: DeviceData, force: bool = False) -> None:
+        if data == self.data and not force:
             return
         self.reset()
         self.data = data
@@ -161,6 +164,7 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         assert self.data
         # self.data.update(self, self.info_box)
         self.update_btns_during_update(False)
+
         self.trigger_update.emit(self.data)
 
     @Slot(bool)
@@ -180,5 +184,5 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         if fdialog.exec_():
             filenames = fdialog.selectedFiles()
             file = filenames[0]
-            # self.data.update(self.progress_box, self.prompt_box, self.info_box, image=file)
+
             self.trigger_update_file.emit(self.data, file)

--- a/nitrokeyapp/overview_tab/__init__.py
+++ b/nitrokeyapp/overview_tab/__init__.py
@@ -1,24 +1,44 @@
 from typing import Optional
 
 from pynitrokey.nk3.admin_app import InitStatus
-from PySide6.QtCore import Signal, Slot
+from PySide6.QtCore import QThread, Signal, Slot
 from PySide6.QtWidgets import QFileDialog, QWidget
 
+from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
-from nitrokeyapp.information_box import InfoBox
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 from nitrokeyapp.worker import Worker
 
+from .worker import OverviewWorker
+
 
 class OverviewTab(QtUtilsMixIn, QWidget):
+    # standard UI
     busy_state_changed = Signal(bool)
 
-    def __init__(self, info_box: InfoBox, parent: Optional[QWidget] = None) -> None:
+    # worker triggers
+    trigger_update = Signal(DeviceData)
+    trigger_update_file = Signal(DeviceData, str)
+
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+    ) -> None:
         QWidget.__init__(self, parent)
         QtUtilsMixIn.__init__(self)
 
         self.data: Optional[DeviceData] = None
-        self.info_box = info_box
+        self.common_ui = CommonUi()
+
+        self.worker_thread = QThread()
+        self._worker = OverviewWorker(self.common_ui)
+        self._worker.moveToThread(self.worker_thread)
+        self.worker_thread.start()
+
+        self.trigger_update.connect(self._worker.update_device)
+        self.trigger_update_file.connect(self._worker.update_device_file)
+
+        self._worker.device_updated.connect(self.device_updated)
 
         # self.ui === self -> this tricks mypy due to monkey-patching self
         self.ui = self.load_ui("overview_tab.ui", self)
@@ -40,14 +60,15 @@ class OverviewTab(QtUtilsMixIn, QWidget):
 
     @property
     def worker(self) -> Optional[Worker]:
-        return None
+        return self._worker
 
     def reset(self) -> None:
         self.data = None
         self.set_device_data("?", "?", "?", "?", "?")
-        self.ui.progressBar_Update.hide()
-        self.ui.progressBar_Download.hide()
-        self.ui.progressBar_Finalization.hide()
+        # self.ui.progressBar_Update.hide()
+        # self.ui.progressBar_Download.hide()
+        # self.ui.progressBar_Finalization.hide()
+        # self.ui.progress_bar.hide()
 
     def refresh(self, data: DeviceData) -> None:
         if data == self.data:
@@ -91,9 +112,9 @@ class OverviewTab(QtUtilsMixIn, QWidget):
     def set_update_enabled(self, enabled: bool) -> None:
         tooltip = ""
         if enabled:
-            self.info_box.hide_status()
+            ...
         else:
-            self.info_box.set_status(
+            self.common_ui.info.info.emit(
                 "Please remove all Nitrokey 3 devices except the one you want to update."
             )
             tooltip = "Please remove all Nitrokey 3 devices except the one you want to update."
@@ -129,7 +150,17 @@ class OverviewTab(QtUtilsMixIn, QWidget):
     @Slot()
     def run_update(self) -> None:
         assert self.data
-        self.data.update(self, self.info_box)
+        # self.data.update(self, self.info_box)
+        self.update_btns_during_update(False)
+        self.trigger_update.emit(self.data)
+
+    @Slot(bool)
+    def device_updated(self, success: bool) -> None:
+        self.update_btns_during_update(True)
+        if success:
+            self.common_ui.info.info.emit("Nitrokey 3 successfully updated")
+        else:
+            self.common_ui.info.error.emit("Nitrokey 3 update failed")
 
     @Slot()
     def update_with_file(self) -> None:
@@ -140,4 +171,5 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         if fdialog.exec_():
             filenames = fdialog.selectedFiles()
             file = filenames[0]
-            self.data.update(self, self.info_box, image=file)
+            # self.data.update(self.progress_box, self.prompt_box, self.info_box, image=file)
+            self.trigger_update_file.emit(self.data, file)

--- a/nitrokeyapp/overview_tab/__init__.py
+++ b/nitrokeyapp/overview_tab/__init__.py
@@ -65,32 +65,41 @@ class OverviewTab(QtUtilsMixIn, QWidget):
     def reset(self) -> None:
         self.data = None
         self.set_device_data("?", "?", "?", "?", "?")
-        # self.ui.progressBar_Update.hide()
-        # self.ui.progressBar_Download.hide()
-        # self.ui.progressBar_Finalization.hide()
-        # self.ui.progress_bar.hide()
 
     def refresh(self, data: DeviceData) -> None:
         if data == self.data:
             return
         self.reset()
         self.data = data
-        if data.status.variant is None:
-            return
 
-        self.set_device_data(
-            str(data.path),
-            str(data.uuid),
-            str(data.version),
-            str(data.status.variant.name),
-            str(data.status.init_status),
-        )
-
-        if data.status.init_status is None:
+        if data.is_bootloader:
+            self.set_device_data(
+                str(data.path),
+                "n/a",
+                "n/a",
+                "n/a",
+                "n/a",
+            )
             self.ui.label_init_status.hide()
             self.ui.nk3_lineedit_init_status.hide()
+            self.ui.moreInfo.hide()
+            self.ui.label_nk3.setText("Nitrokey 3 Bootloader")
+
         else:
-            self.status_error(InitStatus(data.status.init_status))
+            assert data.status.variant
+            self.set_device_data(
+                str(data.path),
+                str(data.uuid),
+                str(data.version),
+                str(data.status.variant.name),
+                str(data.status.init_status),
+            )
+            self.ui.label_nk3.setText("Nitrokey 3")
+            if data.status.init_status is None:
+                self.ui.label_init_status.hide()
+                self.ui.nk3_lineedit_init_status.hide()
+            else:
+                self.status_error(InitStatus(data.status.init_status))
 
     def set_device_data(
         self, path: str, uuid: str, version: str, variant: str, init_status: str

--- a/nitrokeyapp/overview_tab/worker.py
+++ b/nitrokeyapp/overview_tab/worker.py
@@ -1,0 +1,68 @@
+import logging
+from typing import Optional
+
+from PySide6.QtCore import Signal, Slot
+
+from nitrokeyapp.common_ui import CommonUi
+from nitrokeyapp.device_data import DeviceData
+from nitrokeyapp.update import UpdateGUI
+from nitrokeyapp.worker import Job, Worker
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateDevice(Job):
+    device_updated = Signal(bool)
+
+    def __init__(
+        self,
+        common_ui: CommonUi,
+        data: DeviceData,
+    ) -> None:
+        super().__init__(common_ui)
+
+        self.data = data
+
+        self.image: Optional[str] = None
+
+        self.device_updated.connect(lambda _: self.finished.emit())
+
+        self.update_gui = UpdateGUI(self.common_ui)
+        self.common_ui.prompt.confirmed.connect(self.cancel_busy_wait)
+
+    def run(self) -> None:
+        if not self.image:
+            success = self.data.update(self.update_gui)
+        else:
+            success = self.data.update(self.update_gui, self.image)
+        self.device_updated.emit(success)
+
+    @Slot()
+    def cleanup(self) -> None:
+        # TODO: better connection management
+        self.common_ui.prompt.confirmed.disconnect()
+
+    @Slot(bool)
+    def cancel_busy_wait(self, confirmed: bool) -> None:
+        self.update_gui.await_confirmation = confirmed
+
+
+class OverviewWorker(Worker):
+    # TODO: remove DeviceData from signatures
+    device_updated = Signal(bool)
+
+    def __init__(self, common_ui: CommonUi) -> None:
+        super().__init__(common_ui)
+
+    @Slot(DeviceData)
+    def update_device(self, data: DeviceData) -> None:
+        job = UpdateDevice(self.common_ui, data)
+        job.device_updated.connect(self.device_updated)
+        self.run(job)
+
+    @Slot(DeviceData, str)
+    def update_device_file(self, data: DeviceData, filename: str) -> None:
+        job = UpdateDevice(self.common_ui, data)
+        job.image = filename
+        job.device_updated.connect(self.device_updated)
+        self.run(job)

--- a/nitrokeyapp/overview_tab/worker.py
+++ b/nitrokeyapp/overview_tab/worker.py
@@ -35,11 +35,11 @@ class UpdateDevice(Job):
             success = self.data.update(self.update_gui)
         else:
             success = self.data.update(self.update_gui, self.image)
+
         self.device_updated.emit(success)
 
     @Slot()
     def cleanup(self) -> None:
-        # TODO: better connection management
         self.common_ui.prompt.confirmed.disconnect()
 
     @Slot(bool)

--- a/nitrokeyapp/progress_box.py
+++ b/nitrokeyapp/progress_box.py
@@ -39,6 +39,7 @@ class ProgressBox(QObject):
     @Slot()
     def hide(self) -> None:
         self.progress_bar.hide()
+        self.progress_bar.setValue(0)
 
     @Slot(int)
     def update(self, n: int, total: int) -> None:

--- a/nitrokeyapp/progress_box.py
+++ b/nitrokeyapp/progress_box.py
@@ -1,0 +1,100 @@
+import logging
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from PySide6.QtCore import QMetaObject, QObject, QTimer, Signal, Slot
+from PySide6.QtWidgets import QProgressBar
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressUi(QObject):
+    start = Signal(str)
+    stop = Signal()
+    progress = Signal(int, int)
+
+    # def __init__(self, parent: QObject) -> None:
+    # super().__init__(parent)
+    def __init__(self) -> None:
+        super().__init__()
+
+    def connect_ui(self, progress: "ProgressBox") -> None:
+        self.start.connect(progress.show)
+        self.progress.connect(progress.update)
+        self.stop.connect(progress.hide)
+
+    def connect_actions(
+        self,
+        start: Optional[Callable[[str], None]],
+        stop: Optional[Callable[[], None]],
+        progress: Optional[Callable[[int, int], None]],
+    ) -> "ProgressUiConnection":
+        con = ProgressUiConnection(self)
+        if start:
+            con.start = self.start.connect(start)
+        if stop:
+            con.stop = self.stop.connect(stop)
+        if progress:
+            con.progress = self.progress.connect(progress)
+        return con
+
+
+@dataclass
+class ProgressUiConnection:
+    progress_ui: ProgressUi
+    start: Optional[QMetaObject.Connection] = None
+    stop: Optional[QMetaObject.Connection] = None
+    progress: Optional[QMetaObject.Connection] = None
+
+    def disconnect_actions(self) -> None:
+        if self.start:
+            self.progress_ui.start.disconnect()
+            self.start = None
+        if self.stop:
+            self.progress_ui.stop.disconnect()
+            self.stop = None
+        if self.progress:
+            self.progress_ui.progress.disconnect()
+            self.progress = None
+
+
+class ProgressBox(QObject):
+    def __init__(self, progress_bar: QProgressBar):
+        super().__init__()
+
+        self.progress_bar = progress_bar
+
+        self.progress_bar.setTextVisible(True)
+
+        # self.start.connect(self.show)
+        # self.progress.connect(self.update)
+        self.progress_bar.hide()
+        self.progress_bar.setStyleSheet("color: #808080; font: bold;")
+
+        self.hide_timer = QTimer(self)
+        self.hide_timer.setSingleShot(True)
+        self.hide_timer.setInterval(7000)
+        self.hide_timer.timeout.connect(self.hide)
+
+    @Slot(str)
+    def show(self, txt: str) -> None:
+        self.progress_bar.setFormat(f"{txt}: %p%")
+        self.progress_bar.show()
+
+    @Slot()
+    def hide(self) -> None:
+        self.progress_bar.hide()
+
+    @Slot(int)
+    def update(self, n: int, total: int) -> None:
+        value = self.progress_bar.value()
+        if n >= total:
+            self.progress_bar.setValue(100)
+            # self.progress_bar.hide()
+        elif (n * 100 // total) > value:
+            self.progress_bar.setValue((n * 100 // total))
+
+        if self.hide_timer.isActive():
+            self.hide_timer.stop()
+        self.hide_timer.setInterval(7000)
+        self.hide_timer.start()

--- a/nitrokeyapp/progress_box.py
+++ b/nitrokeyapp/progress_box.py
@@ -13,50 +13,8 @@ class ProgressUi(QObject):
     stop = Signal()
     progress = Signal(int, int)
 
-    # def __init__(self, parent: QObject) -> None:
-    # super().__init__(parent)
     def __init__(self) -> None:
         super().__init__()
-
-    def connect_ui(self, progress: "ProgressBox") -> None:
-        self.start.connect(progress.show)
-        self.progress.connect(progress.update)
-        self.stop.connect(progress.hide)
-
-    def connect_actions(
-        self,
-        start: Optional[Callable[[str], None]],
-        stop: Optional[Callable[[], None]],
-        progress: Optional[Callable[[int, int], None]],
-    ) -> "ProgressUiConnection":
-        con = ProgressUiConnection(self)
-        if start:
-            con.start = self.start.connect(start)
-        if stop:
-            con.stop = self.stop.connect(stop)
-        if progress:
-            con.progress = self.progress.connect(progress)
-        return con
-
-
-@dataclass
-class ProgressUiConnection:
-    progress_ui: ProgressUi
-    start: Optional[QMetaObject.Connection] = None
-    stop: Optional[QMetaObject.Connection] = None
-    progress: Optional[QMetaObject.Connection] = None
-
-    def disconnect_actions(self) -> None:
-        if self.start:
-            self.progress_ui.start.disconnect()
-            self.start = None
-        if self.stop:
-            self.progress_ui.stop.disconnect()
-            self.stop = None
-        if self.progress:
-            self.progress_ui.progress.disconnect()
-            self.progress = None
-
 
 class ProgressBox(QObject):
     def __init__(self, progress_bar: QProgressBar):
@@ -66,8 +24,6 @@ class ProgressBox(QObject):
 
         self.progress_bar.setTextVisible(True)
 
-        # self.start.connect(self.show)
-        # self.progress.connect(self.update)
         self.progress_bar.hide()
         self.progress_bar.setStyleSheet("color: #808080; font: bold;")
 

--- a/nitrokeyapp/progress_box.py
+++ b/nitrokeyapp/progress_box.py
@@ -1,8 +1,6 @@
 import logging
-from dataclasses import dataclass
-from typing import Callable, Optional
 
-from PySide6.QtCore import QMetaObject, QObject, QTimer, Signal, Slot
+from PySide6.QtCore import QObject, QTimer, Signal, Slot
 from PySide6.QtWidgets import QProgressBar
 
 logger = logging.getLogger(__name__)
@@ -15,6 +13,7 @@ class ProgressUi(QObject):
 
     def __init__(self) -> None:
         super().__init__()
+
 
 class ProgressBox(QObject):
     def __init__(self, progress_bar: QProgressBar):

--- a/nitrokeyapp/prompt_box.py
+++ b/nitrokeyapp/prompt_box.py
@@ -8,45 +8,8 @@ class PromptUi(QObject):
     confirm = Signal(str, str)
     confirmed = Signal(bool)
 
-    # def __init__(self, parent: QObject) -> None:
-    # super().__init__(parent)
-    # super().__init__()
     def __init__(self) -> None:
         super().__init__()
-
-    # def connect_ui(self, prompt_box: "PromptBox") -> None:
-    #     prompt_box.finished.connect(
-    #         lambda res: self.done.emit(res == QtWidgets.QMessageBox.StandardButton.Ok)
-    #     )
-    #     self.start.connect(prompt_box.confirm)
-
-    # def connect_actions(
-    #     self,
-    #     start: Optional[Callable[[str, str], None]],
-    #     done: Optional[Callable[[bool], None]],
-    # ) -> "PromptUiConnection":
-    #     con = PromptUiConnection(self)
-    #     if start:
-    #         con.start = self.start.connect(start)
-    #     if done:
-    #         con.done = self.done.connect(done)
-    #     return con
-
-
-# @dataclass
-# class PromptUiConnection:
-#     prompt_ui: PromptUi
-#     start: Optional[QMetaObject.Connection] = None
-#     done: Optional[QMetaObject.Connection] = None
-
-#     def disconnect_actions(self) -> None:
-#         if self.start:
-#             self.prompt_ui.start.disconnect()
-#             self.start = None
-#         if self.done:
-#             self.prompt_ui.done.disconnect()
-#             self.done = None
-
 
 class PromptBox(QtWidgets.QMessageBox):
     confirmed = Signal(bool)

--- a/nitrokeyapp/prompt_box.py
+++ b/nitrokeyapp/prompt_box.py
@@ -1,0 +1,73 @@
+from typing import Optional
+
+from PySide6 import QtWidgets
+from PySide6.QtCore import QObject, Signal, Slot
+
+
+class PromptUi(QObject):
+    confirm = Signal(str, str)
+    confirmed = Signal(bool)
+
+    # def __init__(self, parent: QObject) -> None:
+    # super().__init__(parent)
+    # super().__init__()
+    def __init__(self) -> None:
+        super().__init__()
+
+    # def connect_ui(self, prompt_box: "PromptBox") -> None:
+    #     prompt_box.finished.connect(
+    #         lambda res: self.done.emit(res == QtWidgets.QMessageBox.StandardButton.Ok)
+    #     )
+    #     self.start.connect(prompt_box.confirm)
+
+    # def connect_actions(
+    #     self,
+    #     start: Optional[Callable[[str, str], None]],
+    #     done: Optional[Callable[[bool], None]],
+    # ) -> "PromptUiConnection":
+    #     con = PromptUiConnection(self)
+    #     if start:
+    #         con.start = self.start.connect(start)
+    #     if done:
+    #         con.done = self.done.connect(done)
+    #     return con
+
+
+# @dataclass
+# class PromptUiConnection:
+#     prompt_ui: PromptUi
+#     start: Optional[QMetaObject.Connection] = None
+#     done: Optional[QMetaObject.Connection] = None
+
+#     def disconnect_actions(self) -> None:
+#         if self.start:
+#             self.prompt_ui.start.disconnect()
+#             self.start = None
+#         if self.done:
+#             self.prompt_ui.done.disconnect()
+#             self.done = None
+
+
+class PromptBox(QtWidgets.QMessageBox):
+    confirmed = Signal(bool)
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(parent)
+
+        self.finished.connect(self.send_confirmed)
+
+    @Slot(int)
+    def send_confirmed(self, result: int) -> None:
+        self.confirmed.emit(result == QtWidgets.QMessageBox.StandardButton.Ok)
+
+    @Slot(str, str)
+    def confirm(self, title: str, desc: str) -> None:
+        self.setText(desc)
+        self.setWindowTitle(title)
+        self.setStandardButtons(
+            QtWidgets.QMessageBox.StandardButton.Ok
+            | QtWidgets.QMessageBox.StandardButton.Cancel
+        )
+        self.setIcon(QtWidgets.QMessageBox.Icon.Information)
+
+        self.show()

--- a/nitrokeyapp/prompt_box.py
+++ b/nitrokeyapp/prompt_box.py
@@ -11,6 +11,7 @@ class PromptUi(QObject):
     def __init__(self) -> None:
         super().__init__()
 
+
 class PromptBox(QtWidgets.QMessageBox):
     confirmed = Signal(bool)
 

--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -229,6 +229,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         if data == self.data:
             return
         self.data = data
+        self._worker.pin_cache.clear()
 
         self.reset_ui()
         self.trigger_check_device.emit(self.data)

--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -85,14 +85,10 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.trigger_get_credential.connect(self._worker.get_credential)
         self.trigger_edit_credential.connect(self._worker.edit_credential)
 
-        self._worker.pin_cache.pin_cleared.connect(
-            lambda: self.common_ui.info.pin_cached.emit(False)
-        )
+        self._worker.pin_cache.pin_cleared.connect(self.common_ui.info.pin_cleared)
         self._worker.pin_cache.pin_cleared.connect(lambda: self.uncheck_checkbox(True))
 
-        self._worker.pin_cache.pin_cached.connect(
-            lambda: self.common_ui.info.pin_cached.emit(True)
-        )
+        self._worker.pin_cache.pin_cached.connect(self.common_ui.info.pin_cached)
         self.common_ui.info.pin_pressed.connect(self._worker.pin_cache.clear)
 
         self._worker.credential_added.connect(self.credential_added)

--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -235,7 +235,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.data = data
 
         self.reset_ui()
-        self.trigger_check_device.emit(data)
+        self.trigger_check_device.emit(self.data)
 
     @Slot(bool)
     def device_checked(self, compatible: bool) -> None:

--- a/nitrokeyapp/touch.py
+++ b/nitrokeyapp/touch.py
@@ -1,8 +1,7 @@
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
 from PySide6 import QtWidgets
-from PySide6.QtCore import QMetaObject, QObject, QTimer, Signal, Slot
+from PySide6.QtCore import QObject, QTimer, Signal, Slot
 
 from nitrokeyapp.information_box import InfoBox
 from nitrokeyapp.nk3_button import Nk3Button

--- a/nitrokeyapp/touch.py
+++ b/nitrokeyapp/touch.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Optional
+
+from PySide6 import QtWidgets
+from PySide6.QtCore import QMetaObject, QObject, QTimer, Signal, Slot
+
+from nitrokeyapp.information_box import InfoBox
+from nitrokeyapp.nk3_button import Nk3Button
+
+if TYPE_CHECKING:
+    from nitrokeyapp.gui import GUI
+
+
+class TouchUi(QObject):
+    start = Signal()
+    stop = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class TouchIndicator(QtWidgets.QWidget):
+    def __init__(self, info_box: InfoBox, parent: "GUI") -> None:
+        super().__init__(parent)
+
+        # TODO: pass proper type here instead of "all"
+        self.owner = parent
+        self.active_btn: Optional[Nk3Button] = None
+        self.info_box = info_box
+
+        # show status bar info 750ms late
+        t = QTimer(self)
+        t.setSingleShot(True)
+        t.setInterval(750)
+        t.timeout.connect(self.info_box.set_touch_status)
+        self.info_box_timer: QTimer = t
+
+    @Slot()
+    def start(self) -> None:
+        if self.active_btn:
+            return
+
+        self.info_box_timer.start()
+
+        for btn in self.owner.device_buttons:
+            if btn.data == self.owner.selected_device:
+                self.active_btn = btn
+                break
+
+        if self.active_btn:
+            self.active_btn.start_touch()
+
+    @Slot()
+    def stop(self) -> None:
+        if self.active_btn:
+            self.active_btn.stop_touch()
+            self.active_btn = None
+
+        if self.info_box_timer.isActive():
+            self.info_box_timer.stop()
+        self.info_box.hide_touch()

--- a/nitrokeyapp/ui/mainwindow.ui
+++ b/nitrokeyapp/ui/mainwindow.ui
@@ -54,7 +54,7 @@
     <string notr="true"/>
    </property>
    <layout class="QGridLayout" name="gridLayout_2">
-    <item row="1" column="1">
+    <item row="2" column="1">
      <widget class="QFrame" name="information_frame">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -179,7 +179,7 @@
       </layout>
      </widget>
     </item>
-    <item row="0" column="0" rowspan="2" alignment="Qt::AlignHCenter">
+    <item row="0" column="0" rowspan="3" alignment="Qt::AlignHCenter">
      <widget class="QFrame" name="vertical_navigation">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -525,6 +525,19 @@
         </widget>
        </item>
       </layout>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QProgressBar" name="progress_bar">
+      <property name="value">
+       <number>0</number>
+      </property>
+      <property name="textVisible">
+       <bool>true</bool>
+      </property>
+      <property name="format">
+       <string/>
+      </property>
      </widget>
     </item>
    </layout>

--- a/nitrokeyapp/ui/overview_tab.ui
+++ b/nitrokeyapp/ui/overview_tab.ui
@@ -51,8 +51,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>476</width>
-        <height>342</height>
+        <width>482</width>
+        <height>459</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -114,7 +114,6 @@
             </property>
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -315,7 +314,7 @@
                <enum>Qt::AutoText</enum>
               </property>
               <property name="pixmap">
-          			 <pixmap>icons/warning.svg</pixmap>
+               <pixmap>icons/icon_warning.svg</pixmap>
               </property>
               <property name="scaledContents">
                <bool>true</bool>
@@ -390,7 +389,7 @@
          </property>
          <property name="icon">
           <iconset>
-           <normaloff>icons/right_arrow.svg</normaloff>icons/right_arrow.svg</iconset>
+           <normaloff>icons/right_arrow.png</normaloff>icons/right_arrow.png</iconset>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -444,43 +443,8 @@
      </widget>
     </widget>
    </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar_Download">
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="textVisible">
-      <bool>true</bool>
-     </property>
-     <property name="format">
-      <string>Download Firmware %p%</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar_Update">
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="format">
-      <string>Update the Nitrokey %p%</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar_Finalization">
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="format">
-      <string>Finalization %p%</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
- <resources>
-  <include location="resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/nitrokeyapp/update.py
+++ b/nitrokeyapp/update.py
@@ -172,7 +172,11 @@ class Nk3Context:
     ) -> T:
         for t in Retries(retries):
             logger.debug(f"Searching {name} device ({t})")
-            devices = [device for device in list_nk3() if isinstance(device, ty)]
+            try:
+                devices = [device for device in list_nk3() if isinstance(device, ty)]
+            except Exception:
+                # have to catch this, to avoid early exception-raise-out
+                devices = []
             if len(devices) == 0:
                 if callback:
                     callback(int((t.i / retries) * 100), 100)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ black = ">=22.1.0,<23"
 flake8 = "^6.1.0"
 isort = "^5.12.0"
 mypy = ">=1.4,<1.5"
-typing-extensions = "^4.8.0"
 
 [tool.poetry.group.deploy.dependencies]
 pyinstaller = "^6.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ black = ">=22.1.0,<23"
 flake8 = "^6.1.0"
 isort = "^5.12.0"
 mypy = ">=1.4,<1.5"
+typing-extensions = "^4.8.0"
 
 [tool.poetry.group.deploy.dependencies]
 pyinstaller = "^6.3.0"


### PR DESCRIPTION
* migrate current overview and updating to worker concept, thus into a thread
* added `PromptBox` for a app-wide confirmation dialog
* added `ProgressBox` for a app-wide progress bar
* create `OverviewWorker` infrastructure
* move `TouchDialog` and `TouchIndicator` into `touch.py`
* add `DeviceManager` and enable support for Nitrokey 3s in bootloader mode
* updating Nitrokey 3s now possible from bootloader or from within application firmware
* various smaller layout fixes
