### PR TITLE
Fix/catch device removal error from fido2 lib

### DIFF
--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -247,7 +247,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         if self.devices:
             try:
                 nk3_list = [device.uuid() for device in Nitrokey3Device.list()]
-            except OSError as e:
+            except Exception as e:
                 logger.info(f"detect removed failed: {e}")
                 return
             logger.info(f"list nk3: {nk3_list}")

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -70,7 +70,7 @@ class CheckDeviceJob(Job):
                     # TODO: catch a more specific exception
                     pass
         except Exception as e:
-            logger.info("check device job failed: ", repr(e))
+            logger.info(f"check device job failed: {e}")
             compatible = False
 
         self.device_checked.emit(compatible)


### PR DESCRIPTION
`Nitrokey3Device.list()` and the underlying fido2-library is very flaky during connect/disconnect operations and a regular error thrower, thus after trying with catching only `OSError` the newly found issue involves a thrown `Exception` :roll_eyes: 
```
  File "lib/python3.10/site-packages/fido2/hid/__init__.py", line 261, in list_devices
    yield cls(d, open_connection(d))
  File "lib/python3.10/site-packages/fido2/hid/__init__.py", line 112, in __init__
    raise Exception("Wrong nonce")
Exception: Wrong nonce
```
So this PR catches __all__ `Exception`s thrown by it and cancels the `remove_device` operation, which is anyways triggered multiple times so canceling the "bad" ones is fine here.