### PR TITLE
add focus after touch

### DIFF
--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -58,6 +58,7 @@ class Nk3Button(QtWidgets.QPushButton):
         self.animation.stop()
         self.setToolTip("")
         self.effect.setStrength(0)
+        self.setFocus()
 
     def fold(self) -> None:
         self.setText("")


### PR DESCRIPTION
The selected device loses focus in the device list for some actions. 

- After a touch / fix