### PR TITLE
Update used Github Actions in CICD pipelines

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -11,7 +11,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -36,7 +36,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -67,7 +67,7 @@ jobs:
       - name: Build
         run: make build-pyinstaller-onefile
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitrokey-app-onefile
           path: dist/nitrokey-app
@@ -80,7 +80,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitrokey-app-onefile
       - name: Rename binary

--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -88,13 +88,7 @@ jobs:
           mv \
             nitrokey-app \
             nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary
-      - name: Create archive
-        run: |
-          tar \
-          -czvf \
-          nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary.tar.gz \
-          nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
-          files: nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary.tar.gz
+          files: nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -36,7 +36,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         run: make build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitrokeyapp-pypi
           path: dist
@@ -60,9 +60,9 @@ jobs:
       POETRY_PYPI_URL: https://upload.pypi.org/legacy/
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitrokeyapp-pypi
           path: dist

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -145,15 +145,10 @@ jobs:
           mv `
             nitrokey-app.exe `
             nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-binary.exe
-      - name: Create archive
-        run: |
-          7z a -tzip -mx9 `
-            nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-binary.zip `
-            nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-binary.exe
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
-          files: nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-binary.zip
+          files: nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-binary.exe
   publish-msi-installer:
     name: Publish MSI installer
     runs-on: windows-latest

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: choco install poetry --source python
       - name: Create virtual envrionment
@@ -31,7 +31,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: choco install poetry --source python
       - name: Create virtual environment
@@ -49,7 +49,7 @@ jobs:
           make build-ui
           pyinstaller ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitrokey-app-onedir
           path: dist/nitrokey-app
@@ -59,7 +59,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: choco install poetry --source python
       - name: Create virtual environment
@@ -77,7 +77,7 @@ jobs:
           make build-ui
           pyinstaller ci-scripts/windows/pyinstaller/nitrokey-app-onefile.spec
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitrokey-app-onefile
           path: dist/nitrokey-app.exe
@@ -87,9 +87,9 @@ jobs:
     needs: build-onedir
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitrokey-app-onedir
           path: dist/nitrokey-app
@@ -125,7 +125,7 @@ jobs:
             .\Sources.wixobj `
             -o nitrokey-app.msi
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitrokey-app-installer
           path: nitrokey-app.msi
@@ -137,7 +137,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitrokey-app-onefile
       - name: Rename binary
@@ -162,7 +162,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitrokey-app-installer
       - name: Rename installer

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: pip install poetry
       - name: Check pyproject.toml syntax and consistency with poetry.lock
@@ -23,7 +23,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -38,7 +38,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -53,7 +53,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -68,7 +68,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update


### PR DESCRIPTION
This PR updates the Github Actions `actions/checkout`, `actions/download-artifact`, and `actions/upload-artifact` from version 3 to 4. This is required because of the deprecation of NodeJS 16, used by the version 3 of these actions. It also removes the packaging of binary artifacts in an archive.