### PR TITLE
always call show on progress-bar on update

### DIFF
--- a/nitrokeyapp/progress_box.py
+++ b/nitrokeyapp/progress_box.py
@@ -43,6 +43,7 @@ class ProgressBox(QObject):
 
     @Slot(int)
     def update(self, n: int, total: int) -> None:
+        self.progress_bar.show()
         value = self.progress_bar.value()
         if n >= total:
             self.progress_bar.setValue(100)


### PR DESCRIPTION
previously if the time between initializing (`show`) the progress bar and the first `update` was > 7secs (the auto-hide timeout) the progress bar would be updated without being shown.

This case might happen while updating nk3am devices