### PR TITLE
fix copr build

### DIFF
--- a/ci-scripts/linux/rpm/nitrokey-app2.spec
+++ b/ci-scripts/linux/rpm/nitrokey-app2.spec
@@ -6,7 +6,6 @@ Summary:        Graphical application to manage Nitrokey 3 devices
 License:		Apache-2.0
 URL:			https://github.com/nitrokey/%{name}
 Vendor:			Nitrokey
-BuildArch:		x86_64
 
 Source0:		%{URL}/archive/refs/tags/v%{version}.tar.gz
 


### PR DESCRIPTION
the copr build pipeline is confused by the 

`BuildArch:		x86_64`

Line removing it fixes the Problem and successful builds the package 