### PR TITLE
Quit all qthreads on close event

### DIFF
--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -5,7 +5,7 @@ from types import TracebackType
 from typing import Dict, Optional, Type
 
 from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtCore import QEvent, Qt, Signal, Slot
 from PySide6.QtGui import QCursor
 from usbmonitor import USBMonitor
 
@@ -344,3 +344,9 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
 
         dialog = ErrorDialog(self.log_file, self)
         dialog.set_exception(ty, e, tb)
+
+    def closeEvent(self, event: QEvent) -> None:
+        self.overview_tab.worker_thread.quit()
+        self.settings_tab.worker_thread.quit()
+        self.secrets_tab.worker_thread.quit()
+        event.accept()


### PR DESCRIPTION
This PR makes sure that all QThread instances are quit before the application exits. Eventually we need to evaluate if we need to await some of them and how this works together with the `TERM` signal.

Currently, this avoids that users see an `Application quit unexpectedly` or similar error messages.

Fixes #215 