### PR TITLE
Properly disable the Poetry SecretService/Keyring feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ VENV=$(shell poetry env info --path)
 VENV_BIN=$(VENV)/bin
 VENV_PYTHON=$(VENV_BIN)/$(PYTHON)
 
+PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+
 ALL: init build
 
 # setup environment
@@ -15,7 +17,6 @@ update-venv:
 ifeq (, $(shell which poetry))
 $(error "No poetry in $(PATH)")
 endif
-	export PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring
 	poetry env use $(PYTHON)
 	poetry install --sync --without=deploy
 


### PR DESCRIPTION
Poetry fails to install dependencies on KDE Plasma 6 due to some missing D-Bus endpoint. Looks like somebody ran into this issue before but the feature wasn't disabled properly in the Makefile.

The error I ran into looks like this:
```
# make init
export PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring
poetry env use python3
Creating virtualenv nitrokeyapp-0E2Fz7gS-py3.10 in ~/.cache/pypoetry/virtualenvs
Using virtualenv: ~/.cache/pypoetry/virtualenvs/nitrokeyapp-0E2Fz7gS-py3.10
poetry install --sync --without=deploy
Installing dependencies from lock file

Package operations: 41 installs, 1 update, 0 removals

  - Installing pycparser (2.22)
  - Installing shiboken6 (6.7.2): Failed

  DBusErrorResponse

  [org.freedesktop.DBus.Error.UnknownObject] ("No such object path '/org/freedesktop/secrets/prompt/p1'",)

  at ~/.local/pipx/venvs/poetry/lib/python3.10/site-packages/secretstorage/util.py:48 in send_and_get_reply
       44│     def send_and_get_reply(self, msg: Message) -> Any:
       45│         try:
       46│             resp_msg: Message = self._connection.send_and_get_reply(msg)
       47│             if resp_msg.header.message_type == MessageType.error:
    →  48│                 raise DBusErrorResponse(resp_msg)
       49│             return resp_msg.body
       50│         except DBusErrorResponse as resp:
       51│             if resp.name in (DBUS_UNKNOWN_METHOD, DBUS_NO_SUCH_OBJECT):
       52│                 raise ItemNotFoundException('Item does not exist!') from resp

Cannot install shiboken6.

make: *** [Makefile:20: update-venv] Error 1
```
