### PR TITLE
recognize and handle too old firmwares; fixes #273

### DIFF
--- a/nitrokeyapp/device_data.py
+++ b/nitrokeyapp/device_data.py
@@ -37,6 +37,18 @@ class DeviceData:
         return not isinstance(self._device, TrussedDevice)
 
     @property
+    def is_too_old(self) -> bool:
+        try:
+            self.name
+            self.version
+            self.status
+            self.status.variant
+            return False
+
+        except Exception:
+            return True
+
+    @property
     def status(self) -> Status:
         assert isinstance(self._device, TrussedDevice)
         if not self._status:

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -282,6 +282,11 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         self.info_box.set_device(data.name)
         self.tabs.show()
         self.tabs.setCurrentIndex(0)
+
+        if self.selected_device.is_too_old:
+            self.tabs.setTabEnabled(1, False)
+            self.tabs.setTabEnabled(2, False)
+
         self.show_navigation()
         self.welcome_widget.hide()
 

--- a/nitrokeyapp/overview_tab/__init__.py
+++ b/nitrokeyapp/overview_tab/__init__.py
@@ -78,6 +78,22 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         self.data = data
         self.hide_more_options()
 
+        # catch too old firmware
+        if data.is_too_old:
+            self.set_device_data(
+                str(data.path),
+                "n/a",
+                "n/a",
+                "Update Your Nitrokey 3 for full functionality",
+                "n/a",
+            )
+            self.ui.status_label.hide()
+            self.ui.nk3_status.hide()
+            self.ui.more_info.hide()
+            self.ui.nk3_label.setText("Nitrokey 3 (old firmware)")
+            self.status_error(InitStatus(0))
+            return
+
         if data.is_bootloader:
             self.set_device_data(
                 str(data.path),
@@ -110,7 +126,12 @@ class OverviewTab(QtUtilsMixIn, QWidget):
                 self.ui.nk3_status.show()
 
     def set_device_data(
-        self, path: str, uuid: str, version: str, variant: str, init_status: str
+        self,
+        path: str,
+        uuid: str,
+        version: str,
+        variant: str,
+        init_status: str,
     ) -> None:
         self.ui.nk3_path.setText(path)
         self.ui.nk3_uuid.setText(uuid)


### PR DESCRIPTION
Introduce `DeviceData.is_too_old` to test the Nitrokey 3 for important features being used. To be extended with whatever further identifies functionality which is used in `nkapp2`.

If the firmware is classified as too old:
* disable Settings + Passwords tab
* inform the user about the situation in Overview tab
* still allow "update" to be run
