### PR TITLE
Adapt build dependencies

### DIFF
--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -46,7 +46,6 @@ jobs:
       - name: Build onedir
         run: |
           Invoke-Expression "$(poetry env info --path)\Scripts\Activate.ps1"
-          make build-ui
           pyinstaller ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -74,7 +73,6 @@ jobs:
       - name: Build onefile
         run: |
           Invoke-Expression "$(poetry env info --path)\Scripts\Activate.ps1"
-          make build-ui
           pyinstaller ci-scripts/windows/pyinstaller/nitrokey-app-onefile.spec
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
@@ -8,16 +8,13 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
-    (venv_path + '/lib/python' + python_version + '/site-packages/pynitrokey/VERSION', 'pynitrokey'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 
 block_cipher = None
@@ -26,9 +23,7 @@ block_cipher = None
 a = Analysis(
     ['../../../nitrokeyapp/__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '/lib/python' + python_version + '/site-packages/libusbsio/bin/linux_x86_64/libusbsio.so', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
@@ -8,16 +8,13 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
-    (venv_path + '/lib/python' + python_version + '/site-packages/pynitrokey/VERSION', 'pynitrokey'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 
 block_cipher = None
@@ -26,9 +23,7 @@ block_cipher = None
 a = Analysis(
     ['../../../nitrokeyapp/__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '/lib/python' + python_version + '/site-packages/libusbsio/bin/linux_x86_64/libusbsio.so', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
@@ -8,23 +8,18 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
-    (venv_path + '/lib/python' + python_version + '/site-packages/pynitrokey/VERSION', 'pynitrokey'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 a = Analysis(
     ['../../../nitrokeyapp/__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '/lib/python' + python_version + '/site-packages/libusbsio/bin/osx_arm64/libusbsio.dylib', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
@@ -8,23 +8,18 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
-    (venv_path + '/lib/python' + python_version + '/site-packages/pynitrokey/VERSION', 'pynitrokey'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 a = Analysis(
     ['../../../nitrokeyapp/__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '/lib/python' + python_version + '/site-packages/libusbsio/bin/osx_x86_64/libusbsio.dylib', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
@@ -8,23 +8,18 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
-    (venv_path + '/lib/python' + python_version + '/site-packages/pynitrokey/VERSION', 'pynitrokey'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 a = Analysis(
     ['../../../nitrokeyapp/__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '/lib/python' + python_version + '/site-packages/libusbsio/bin/osx_arm64/libusbsio.dylib', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
@@ -8,23 +8,18 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
-    (venv_path + '/lib/python' + python_version + '/site-packages/pynitrokey/VERSION', 'pynitrokey'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 a = Analysis(
     ['../../../nitrokeyapp/__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '/lib/python' + python_version + '/site-packages/libusbsio/bin/osx_x86_64/libusbsio.dylib', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
@@ -5,7 +5,6 @@ import os
 venv_path = os.popen('poetry env info --path').read().rstrip()
 
 datas = [
-    (venv_path + '\\Lib\\site-packages\\pynitrokey\\VERSION', 'pynitrokey'),
     (venv_path + '\\Lib\\site-packages\\fido2\\public_suffix_list.dat', 'fido2'),
     ('..\\..\\..\\nitrokeyapp\\ui', 'nitrokeyapp\\ui'),
     ('..\\..\\..\\LICENSE', '.')
@@ -13,9 +12,7 @@ datas = [
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 
 block_cipher = None
@@ -24,10 +21,7 @@ block_cipher = None
 a = Analysis(
     ['..\\..\\..\\nitrokeyapp\\__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '\\Lib\\site-packages\\libusbsio\\bin\\x64\\libusbsio.dll', 'libusbsio'),
-        (venv_path + '\\Lib\\site-packages\\usb1\\libusb-1.0.dll', '.')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/windows/pyinstaller/nitrokey-app-onefile.spec
+++ b/ci-scripts/windows/pyinstaller/nitrokey-app-onefile.spec
@@ -5,7 +5,6 @@ import os
 venv_path = os.popen('poetry env info --path').read().rstrip()
 
 datas = [
-    (venv_path + '\\Lib\\site-packages\\pynitrokey\\VERSION', 'pynitrokey'),
     (venv_path + '\\Lib\\site-packages\\fido2\\public_suffix_list.dat', 'fido2'),
     ('..\\..\\..\\nitrokeyapp\\ui', 'nitrokeyapp\\ui'),
     ('..\\..\\..\\LICENSE', '.')
@@ -13,9 +12,7 @@ datas = [
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
-datas += copy_metadata('pynitrokey')
-datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
+datas += copy_metadata('nitrokey')
 
 
 block_cipher = None
@@ -24,10 +21,7 @@ block_cipher = None
 a = Analysis(
     ['..\\..\\..\\nitrokeyapp\\__main__.py'],
     pathex=[],
-    binaries=[
-        (venv_path + '\\Lib\\site-packages\\libusbsio\\bin\\x64\\libusbsio.dll', 'libusbsio'),
-        (venv_path + '\\Lib\\site-packages\\usb1\\libusb-1.0.dll', '.')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],


### PR DESCRIPTION
This PR change the build dependencies for the CD pipeline to take the recent changes from `pynitrokey` to `nitrokey` dependency into account. It also remove a not needed invocation of `make build-ui` in the Windows pipeline.