### PR TITLE
Lint and fix appstream metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,3 +77,13 @@ jobs:
         run: make init
       - name: Check code static typing
         run: make check-typing
+  lint-flatpak-metadata:
+    name: Check flatpak metadata
+    runs-on: ubuntu-latest
+    container: ghcr.io/flathub/flatpak-builder-lint:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check appstream metadata
+        run: flatpak-builder-lint appstream meta/com.nitrokey.nitrokey-app2.metainfo.xml
+

--- a/meta/com.nitrokey.nitrokey-app2.metainfo.xml
+++ b/meta/com.nitrokey.nitrokey-app2.metainfo.xml
@@ -17,8 +17,8 @@
     <category>Qt</category>
   </categories>
   <releases>
-    <release version="2.3.1" date="2024-07-19"/>
     <release version="2.3.2" date="2024-09-24"/>
+    <release version="2.3.1" date="2024-07-19"/>
   </releases>
   <provides>
     <binary>nitrokeyapp</binary>


### PR DESCRIPTION
CI still fails because it cannot reach nitrokey.com (403).  Let’s see if that is a temporary or persistent problem.