### PR TITLE
Update RPM specification file

### DIFF
--- a/ci-scripts/linux/rpm/nitrokey-app2.spec
+++ b/ci-scripts/linux/rpm/nitrokey-app2.spec
@@ -1,72 +1,75 @@
 Name:           nitrokey-app2
 Version:        2.3.2
-Release:        1%{?dist}
+Release:        %autorelease
 Summary:        Graphical application to manage Nitrokey 3 devices
 
-License:		Apache-2.0
-URL:			https://github.com/nitrokey/%{name}
-Vendor:			Nitrokey
+License:        Apache-2.0
+URL:            https://github.com/nitrokey/nitrokey-app2
+Vendor:         Nitrokey
 
-Source0:		%{URL}/archive/refs/tags/v%{version}.tar.gz
+Source0:        %{URL}/archive/refs/tags/v%{version}.tar.gz
 
-BuildRequires: atk
-BuildRequires: binutils
-BuildRequires: cairo-gobject
-BuildRequires: dbus-libs
-BuildRequires: gdk-pixbuf2
-BuildRequires: gtk3
-BuildRequires: libxkbcommon
-BuildRequires: libwayland-client
-BuildRequires: libwayland-cursor
-BuildRequires: libwayland-egl
-BuildRequires: libxkbcommon-x11
-BuildRequires: libX11-xcb
-BuildRequires: make
-BuildRequires: pango
-BuildRequires: poetry
-BuildRequires: python3.9
-BuildRequires: python3-devel
-BuildRequires: which
-BuildRequires: xcb-util-wm
-BuildRequires: xcb-util-keysyms
-BuildRequires: xcb-util-image
-BuildRequires: xcb-util-cursor
-BuildRequires: xcb-util-renderutil
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  %{py3_dist nitrokey}
+BuildRequires:  %{py3_dist usb-monitor}
+BuildRequires:  %{py3_dist pyside6}
 
-Requires: glibc
-Requires: zlib
-
-%global debug_package %{nil}
+Requires:       atk
+Requires:       binutils
+Requires:       cairo-gobject
+Requires:       dbus-libs
+Requires:       gdk-pixbuf2
+Requires:       glibc
+Requires:       gtk3
+Requires:       libxkbcommon
+Requires:       libwayland-client
+Requires:       libwayland-cursor
+Requires:       libwayland-egl
+Requires:       libxkbcommon-x11
+Requires:       libX11-xcb
+Requires:       pango
+Requires:       xcb-util-wm
+Requires:       xcb-util-keysyms
+Requires:       xcb-util-image
+Requires:       xcb-util-cursor
+Requires:       xcb-util-renderutil
+Requires:       zlib
 
 %description
 %{summary}.
 
 %prep
-%autosetup -v
+%autosetup -n nitrokey-app2-%{version}
+
+%generate_buildrequires
+%pyproject_buildrequires
 
 %build
-poetry env use python3.9
-poetry install
-make build-pyinstaller-onedir
+%pyproject_wheel
 
 %install
-%define _build_id_links none
-mkdir -p %{buildroot}%{_libdir}/%{name}
-cp -r dist/nitrokey-app/* %{buildroot}%{_libdir}/%{name}
-mkdir -p %{buildroot}%{_bindir}
-ln -s %{_libdir}/%{name}/nitrokey-app %{buildroot}%{_bindir}/%{name}
+%pyproject_install
+%pyproject_save_files nitrokeyapp
+mv %{buildroot}%{_bindir}/nitrokeyapp %{buildroot}%{_bindir}/%{name}
 mkdir -p %{buildroot}%{_datadir}/icons/hicolor
 cp -r ci-scripts/linux/rpm/icons/hicolor/* %{buildroot}%{_datadir}/icons/hicolor
 mkdir -p %{buildroot}%{_datadir}/applications
 cp ci-scripts/linux/rpm/nitrokey-app2.desktop %{buildroot}%{_datadir}/applications
 
-%files
+%check
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
 %{_bindir}/%{name}
-%{_libdir}/%{name}
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
 %{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
 %{_datadir}/applications/%{name}.desktop
 
 %changelog
+* Mon Nov 04 2024 Markus Merklinger <markus@nitrokey.com> - 2.3.2-1
+- Changed the build process and dependencies.
+
 * Wed Jan 10 2024 Markus Merklinger <markus@nitrokey.com> - 2.1.5-1
 - First release of package


### PR DESCRIPTION
This PR updates the RPM specification file to take into account the new build process.

Detailed changes:
- Remove build with _pyinstaller_ and the associated build requirements.
- Introduce new Python dependencies which are partly maintained by Nitrokey.
- Make use of more RPM macros.