### PR TITLE
Remove unused mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,6 @@ module = [
   "win32api.*",
   "win32con.*",
   "win32gui.*",
-  "pyudev.*",
-  "ruamel.*",
-  "tlv8.*",
-  "qt_material.*",
-	"usbmonitor.*",
+  "usbmonitor.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
This PR removes unused mypy overrides in `pyproject.toml`.

Detailed mypy override changes:
- Remove `pyudev`. Dependency remove in f1d39e2aa74f0cdfc32298ab3ddd839cf1270fae.
- Remove `ruamel`. Dependency of `pynitrokey`.
- Remove `tlv8`. Dependency of `nitrokey` (`nitrokey-sdk-py`).
- Remove `qt_material`. Dependency removed in e59caa26ec75708b709142a9c17c9abda6a3606b.