### PR TITLE
Remove `ecdsa` dependency from pyinstaller build

### DIFF
--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
@@ -11,7 +11,6 @@ datas = [
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
@@ -11,7 +11,6 @@ datas = [
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
@@ -11,7 +11,6 @@ datas = [
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
@@ -11,7 +11,6 @@ datas = [
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
@@ -11,7 +11,6 @@ datas = [
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
@@ -11,7 +11,6 @@ datas = [
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
     ('../../../LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
@@ -9,7 +9,6 @@ datas = [
     ('..\\..\\..\\nitrokeyapp\\ui', 'nitrokeyapp\\ui'),
     ('..\\..\\..\\LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')

--- a/ci-scripts/windows/pyinstaller/nitrokey-app-onefile.spec
+++ b/ci-scripts/windows/pyinstaller/nitrokey-app-onefile.spec
@@ -9,7 +9,6 @@ datas = [
     ('..\\..\\..\\nitrokeyapp\\ui', 'nitrokeyapp\\ui'),
     ('..\\..\\..\\LICENSE', '.')
 ]
-datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('nitrokeyapp')
 datas += copy_metadata('nitrokey')


### PR DESCRIPTION
This PR removes the metadata copying for the `ecdsa` dependency from the *pyinstaller* build.