### PR TITLE
List NK3 and NKPK devices

### DIFF
--- a/nitrokeyapp/device_data.py
+++ b/nitrokeyapp/device_data.py
@@ -23,7 +23,9 @@ class DeviceData:
 
     @classmethod
     def list(cls) -> List["DeviceData"]:
-        return [cls(dev) for dev in nk3.list()]
+        nk3_devices = [cls(dev) for dev in nk3.list()]
+        nkpk_devices = [cls(dev) for dev in nkpk.list()]
+        return nk3_devices + nkpk_devices
 
     @property
     def name(self) -> str:

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -159,8 +159,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             logger.info("failed adding device")
             return
 
-        # add as nk3 device
-        logger.info(f"nk3 connected: {devs}")
+        logger.info(f"Connected devices: {devs}")
 
         self.trigger_update_devices.emit()
 


### PR DESCRIPTION
This adds support for the Nitrokey Passkey.

Changes:
- Recognize Nitrokey 3 and Nitrokey Passkey.

Todo:
- Change title in overview tab.
- Make sure the update is performed for the correct model.
- Hide passwords tab for Nitrokey Passkey.
- Hide "Passwords" entry in settings tab.