### PR TITLE
Enable full diff for poetry.lock file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+poetry.lock linguist-generated=false


### PR DESCRIPTION
Per default, GitHub treats poetry.lock as a generated file and hides its diff in pull requests.  That can be confusing if the locked dependency version changes without a corresponding change in pyproject.toml.  This patch marks poetry.lock as not auto-generated so that the full diff is shown.

See also: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github