### PR TITLE
CI triggering adjustments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,11 @@
 name: Continuous integration
 on:
   push:
-    branches-ignore:
-      - "main"
+    branches:
+      - main
   pull_request:
-
+  workflow_dispatch:
+    
 jobs:
   pyproject-lock-file-check:
     name: Check pyproject syntax


### PR DESCRIPTION
* change how the ci is triggered
* avoid double runs

* any PRs are triggering the CI runs: 
* w/o a PR a branch can run the CI manually
* merges into `main` will trigger a CI run