### PR TITLE
fix flathub metadata-lint warning

### DIFF
--- a/meta/com.nitrokey.nitrokey-app2.metainfo.xml
+++ b/meta/com.nitrokey.nitrokey-app2.metainfo.xml
@@ -45,6 +45,8 @@
       <caption>Main window</caption>
     </screenshot>
   </screenshots>
-  <developer_name>Nitrokey GmbH</developer_name>
+  <developer id="com.nitrokey">
+    <name>Nitrokey GmbH</name>
+  </developer>
   <update_contact>info_AT_nitrokey.com</update_contact>
 </component>


### PR DESCRIPTION
only the `developer` warning so far, partly fixes #311 