### PR TITLE
Update nitrokey-sdk-py to v0.4

### DIFF
--- a/nitrokeyapp/device_data.py
+++ b/nitrokeyapp/device_data.py
@@ -6,7 +6,7 @@ from nitrokey.nk3 import NK3, NK3Bootloader
 from nitrokey.trussed import TrussedBase, TrussedDevice, Uuid, Version
 from nitrokey.trussed.admin_app import Status
 
-from nitrokeyapp.update import Nk3Context, UpdateGUI
+from nitrokeyapp.update import Nk3Context, UpdateGUI, UpdateResult, UpdateStatus
 
 logger = logging.getLogger(__name__)
 
@@ -106,14 +106,12 @@ class DeviceData:
         self,
         ui: UpdateGUI,
         image: Optional[str] = None,
-    ) -> bool:
+    ) -> UpdateResult:
         self.updating = True
-        try:
-            Nk3Context(self.path).update(ui, image)
+        result = Nk3Context(self.path).update(ui, image)
+        if result.status == UpdateStatus.SUCCESS:
             logger.info("Nitrokey 3 successfully updated")
-            self.updating = False
-            return True
-        except Exception as e:
-            logger.info(f"Nitrokey 3 failed to update - {e}")
-            self.updating = False
-            return False
+        else:
+            logger.error(f"Nitrokey 3 update failed: {result}")
+        self.updating = False
+        return result

--- a/nitrokeyapp/overview_tab/worker.py
+++ b/nitrokeyapp/overview_tab/worker.py
@@ -5,14 +5,14 @@ from PySide6.QtCore import Signal, Slot
 
 from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
-from nitrokeyapp.update import UpdateGUI
+from nitrokeyapp.update import UpdateGUI, UpdateResult
 from nitrokeyapp.worker import Job, Worker
 
 logger = logging.getLogger(__name__)
 
 
 class UpdateDevice(Job):
-    device_updated = Signal(bool)
+    device_updated = Signal(UpdateResult)
 
     def __init__(
         self,
@@ -34,11 +34,11 @@ class UpdateDevice(Job):
 
     def run(self) -> None:
         if not self.image:
-            success = self.data.update(self.update_gui)
+            result = self.data.update(self.update_gui)
         else:
-            success = self.data.update(self.update_gui, self.image)
+            result = self.data.update(self.update_gui, self.image)
 
-        self.device_updated.emit(success)
+        self.device_updated.emit(result)
 
     @Slot()
     def cleanup(self) -> None:
@@ -51,7 +51,7 @@ class UpdateDevice(Job):
 
 class OverviewWorker(Worker):
     # TODO: remove DeviceData from signatures
-    device_updated = Signal(bool)
+    device_updated = Signal(UpdateResult)
 
     def __init__(self, common_ui: CommonUi) -> None:
         super().__init__(common_ui)

--- a/poetry.lock
+++ b/poetry.lock
@@ -671,24 +671,24 @@ files = [
 
 [[package]]
 name = "nitrokey"
-version = "0.3.2"
+version = "0.4.0"
 description = "Nitrokey Python SDK"
 optional = false
-python-versions = "<4.0.0,>=3.9.2"
+python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "nitrokey-0.3.2-py3-none-any.whl", hash = "sha256:f0e91d57a9958dc785019424cd9e1e22a4ff2d7348496acd27aa5f238d81b0b2"},
-    {file = "nitrokey-0.3.2.tar.gz", hash = "sha256:240828ac0d95f961e0aadc24f1f10f8ddc28a20ed0df193ddda2922749b11e44"},
+    {file = "nitrokey-0.4.0-py3-none-any.whl", hash = "sha256:743a660042999c6298e394df3822e16f57e4898fa37bd20a916569faef58816a"},
+    {file = "nitrokey-0.4.0.tar.gz", hash = "sha256:b99dca17ef0f530563c1fef76ee169abfe85bbe7ea91f21e70fdc0df7166b4a9"},
 ]
 
 [package.dependencies]
-crcmod = ">=1.7,<2.0"
+crcmod = ">=1.7,<2"
 cryptography = ">=41"
 fido2 = ">=1.1.2,<3"
 hidapi = ">=0.14,<0.15"
-protobuf = ">=5.26,<6.0"
-pyserial = ">=3.5,<4.0"
-requests = ">=2,<3"
+protobuf = ">=5.26,<6"
+pyserial = ">=3.5,<4"
+requests = ">=2.16,<3"
 semver = ">=3,<4"
 tlv8 = ">=0.10,<0.11"
 
@@ -1242,4 +1242,4 @@ tests = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "08abbdb185e754fb3de5bb63a5e7c1cbe4ed522a33f45cd3d22a479e6206cdba"
+content-hash = "ca81edcce5bdd228d755ea7b2766bcc31421a412c5a85be58b5fc1bad7b5a2c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 fido2 = "^2"
-nitrokey = "^0.3.2"
+nitrokey = "^0.4"
 pySide6 = ">=6.6.0"
 pywin32 = { version = "305", markers = "sys_platform =='win32'" }
 usb-monitor = "^1.21"


### PR DESCRIPTION
This PR updates nitrokey-sdk-py to v0.4, checks the device status after the update and improves the way errors are displayed during firmware updates.

For example, trying to update to an older version now leads to this message:
<img width="919" height="82" alt="abort-old-version" src="https://github.com/user-attachments/assets/52738e6f-eb3f-4299-abdd-6f57354781c0" />

And the potential EFS error after updating to v1.8.2 looks like this:
<img width="1271" height="91" alt="error-efs-reformat" src="https://github.com/user-attachments/assets/a4e5528e-7e2f-4810-bddb-a4c72c14ec8d" />

Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/296
Fixes: https://github.com/Nitrokey/nitrokey-app2/issues/339