### PR TITLE
ci: Don’t build flatpak bundle for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,7 @@ jobs:
           if [ $PACKAGE_VERSION == $FLATPAK_VERSION ]; then exit 0; else exit 1; fi
   flatpak-build:
     name: Flatpak bundle build
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.8


### PR DESCRIPTION
Building the flatpak bundle is rather slow (> 10 min) and not necessary for most PRs. With this patch, it is only built for pushes to main or manually triggered workflow runs.  This still allows us to catch errors before a release but does not slow down development.