### PR TITLE
Removes spaces and minus signs when saving the OTP entry

### DIFF
--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -605,7 +605,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         tool_Tip = "Credeantial cannot be saved:"
         can_save = True
-        check_secret = self.ui.otp.text()
+        check_secret = self.ui.otp.text().replace(" ", "").replace("-", "")
 
         name_len = len(str.encode(self.ui.name.text()))
         username_len = len(str.encode(self.ui.username.text()))
@@ -839,7 +839,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
                     otherKind = OtherKind.from_str(kind_str)
                 else:
                     kind = OtpKind.from_str(kind_str)
-                otp_secret = self.ui.otp.text()
+                otp_secret = self.ui.otp.text().replace(" ", "").replace("-", "")
                 secret = parse_base32(otp_secret)
             except RuntimeError:
                 pass


### PR DESCRIPTION
Some sites, such as PayPal and others, output the OTP string with spaces after every 4th character.

Entering this string results in the error message `Secret is not in Base32`.
However, removing the spaces makes it work. To be on the safe side, the pull request also removes the minus sign, too.

The pull request is untested because I don't have a suitable environment for testing and I haven't checked whether the other OTP variants contain spaces.