### PR TITLE
Fix FIDO2 reset error message

### DIFF
--- a/nitrokeyapp/settings_tab/__init__.py
+++ b/nitrokeyapp/settings_tab/__init__.py
@@ -355,8 +355,7 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         self.ui.btn_save.hide()
 
         self.ui.warning_label.setText(
-            "**Reset for FIDO2 is only possible 10secs "
-            + "after plugging in the device.**"
+            "**Reset for FIDO 2 is only possible within 10secs after plugging in the device.**"
         )
 
         if state == State.FidoReset:


### PR DESCRIPTION
This PR makes the FIDO2 error message more precise to indicate that the reset is only possible within the 10 seconds of plugging in the Nitrokey.

Fixes #377 