### PR TITLE
Error dialog: make the spacer fixed so that the error box scales with the dialog

### DIFF
--- a/nitrokeyapp/ui/error_dialog.ui
+++ b/nitrokeyapp/ui/error_dialog.ui
@@ -32,7 +32,7 @@
       </font>
      </property>
      <property name="lineWrapMode">
-      <enum>QPlainTextEdit::NoWrap</enum>
+      <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>
@@ -42,7 +42,10 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -55,10 +58,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
# Before the fix:

<img width="918" height="611" alt="image" src="https://github.com/user-attachments/assets/85b09eaf-0c7f-4ca6-bb6c-5b6fa5b5ad9e" />

# After the fix:

<img width="832" height="508" alt="image" src="https://github.com/user-attachments/assets/aa1a5ac7-e2dc-44df-8626-95dfb223c097" />
