### PR TITLE
metainfo: Add vcs-browser URL

### DIFF
--- a/meta/com.nitrokey.nitrokey-app2.metainfo.xml
+++ b/meta/com.nitrokey.nitrokey-app2.metainfo.xml
@@ -46,6 +46,7 @@
   <url type="homepage">https://www.nitrokey.com/</url>
   <url type="bugtracker">https://github.com/Nitrokey/nitrokey-app2/issues</url>
   <url type="help">https://docs.nitrokey.com/software/nk-app2</url>
+  <url type="vcs-browser">https://github.com/Nitrokey/nitrokey-app2</url>
   <screenshots>
     <screenshot type="default">
       <image>https://github.com/Nitrokey/nitrokey-app2/blob/main/meta/screenshot.png?raw=true</image>


### PR DESCRIPTION
The vcs-browser URL points to a webpage on which the user can browser the sourcecode, in this case the GitHub repository.  This fixes a new warning in the flathub linter.

See also:
    https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url
    https://github.com/flathub/com.nitrokey.nitrokey-app2/pull/13