### PR TITLE
ci: Fix runner for version-check job in cd-linux-arm64

### DIFF
--- a/.github/workflows/cd-linux-arm64.yaml
+++ b/.github/workflows/cd-linux-arm64.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   version-check:
     name: Check versioning
-    runs-on: ubuntu-24.02-arm
+    runs-on: ubuntu-24.04-arm
     container: python:3.10-slim-trixie
     if: github.event_name == 'release'
     steps:


### PR DESCRIPTION
ubuntu-24.02-arm does not exist thus the job times out: https://github.com/Nitrokey/nitrokey-app2/actions/runs/21412081783