### PR TITLE
Add minimum dependency age

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,11 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+
+env:
+  UV_EXCLUDE_NEWER: 0 days
+  PIP_UPLOADED_PRIOR_TO: P0D
+  POETRY_SOLVER_MIN_RELEASE_AGE: 0
     
 jobs:
   pyproject-lock-file-check:

--- a/.pip/pip.conf
+++ b/.pip/pip.conf
@@ -1,0 +1,2 @@
+[global]
+uploaded-prior-to = P7D

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[solver]
+min-release-age = 7
+min-release-age-exclude = ["nitrokey"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,8 @@ module = [
   "usbmonitor.*",
 ]
 ignore_missing_imports = true
+
+[tool.uv]
+exclude-newer = "7 days"
+# Can be used to update packages to a version more recent what exclude-newer allows
+exclude-newer-package = { nitrokey = false }


### PR DESCRIPTION
This adds a configuration so that poetry, uv and pip don't consider releases that are less than 7 days old to reduce the risk of installing malware through simple dependency update.

This PR also adds an exclusion for the `nitrokey` package, as it's most likely that a compromise to the `nitropy` package would mean our python packages can all  be compromised, and `nitropy` and `nitrokey-app2` are generally updated in sync with the sdk.