### PR TITLE
Add CTAPHID env var, HMAC PIN/touch options, and fix clipboard clear …

### DIFF
--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -859,7 +859,6 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.comment_label.hide()
         self.ui.comment.hide()
 
-
     def hide_hmac_view(self) -> None:
         if self.active_credential is None and self.ui.name_label.text() == "HmacSlot2":
             self.ui.name_label.clear()
@@ -878,7 +877,6 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         self.ui.comment_label.show()
         self.ui.comment.show()
-
 
     @Slot()
     def hide_otp(self) -> None:

--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -197,6 +197,15 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         for field in self.line2copy_action:
             field.installEventFilter(self)
 
+        self._clipboard_expected: dict[QLineEdit, str] = {}
+        self._clipboard_timers: dict[QLineEdit, QTimer] = {}
+        for field in self.line2copy_action:
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.setInterval(CLIPBOARD_CLEAR_TIMEOUT_MS)
+            timer.timeout.connect(lambda f=field: self._clear_clipboard_for_field(f))
+            self._clipboard_timers[field] = timer
+
         self.ui.btn_add.pressed.connect(self.add_new_credential)
         self.ui.btn_abort.pressed.connect(lambda: self.show_secrets(True))
         self.ui.btn_save.pressed.connect(self.save_credential)
@@ -428,6 +437,9 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.is_pin_protected.setChecked(credential.protected)
         self.ui.is_touch_protected.setChecked(credential.touch_required)
 
+        self.ui.is_pin_protected.setEnabled(False)
+        self.ui.is_touch_protected.setEnabled(False)
+
         self.hide_hmac_view()
 
         self.hide_otp()
@@ -557,7 +569,6 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         if credential.other == OtherKind.HMAC:
             self.show_hmac_view()
-            self.ui.btn_save.setEnabled(False)
         else:
             self.hide_hmac_view()
 
@@ -724,10 +735,12 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         QTimer.singleShot(
             5000, lambda: self.line2copy_action[obj].setIcon(self.get_qicon("content_copy.svg"))
         )
-        QTimer.singleShot(CLIPBOARD_CLEAR_TIMEOUT_MS, lambda: self.clear_clipboard(copied_text))
+        self._clipboard_expected[obj] = copied_text
+        self._clipboard_timers[obj].start()
 
-    def clear_clipboard(self, expected_text: str) -> None:
-        if self.clipboard.text() == expected_text:
+    def _clear_clipboard_for_field(self, field: QLineEdit) -> None:
+        expected = self._clipboard_expected.pop(field, None)
+        if expected is not None and self.clipboard.text() == expected:
             self.clipboard.clear()
 
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
@@ -738,10 +751,9 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             and event.matches(QKeySequence.StandardKey.Copy)
         ):
             selected = obj.selectedText()
-            if selected:
-                QTimer.singleShot(
-                    CLIPBOARD_CLEAR_TIMEOUT_MS, lambda: self.clear_clipboard(selected)
-                )
+            if selected and obj in self._clipboard_timers:
+                self._clipboard_expected[obj] = selected
+                self._clipboard_timers[obj].start()
         return False
 
     def act_password_show(self) -> None:
@@ -847,11 +859,6 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.comment_label.hide()
         self.ui.comment.hide()
 
-        self.ui.is_pin_protection_label.hide()
-        self.ui.is_pin_protected.hide()
-
-        self.ui.is_touch_protection_label.hide()
-        self.ui.is_touch_protected.hide()
 
     def hide_hmac_view(self) -> None:
         if self.active_credential is None and self.ui.name_label.text() == "HmacSlot2":
@@ -872,11 +879,6 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.comment_label.show()
         self.ui.comment.show()
 
-        self.ui.is_pin_protection_label.show()
-        self.ui.is_pin_protected.show()
-
-        self.ui.is_touch_protection_label.show()
-        self.ui.is_touch_protected.show()
 
     @Slot()
     def hide_otp(self) -> None:

--- a/nitrokeyapp/utils.py
+++ b/nitrokeyapp/utils.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 def should_use_ccid() -> bool:
     if os.environ.get(NITROKEY_FORCE_CTAPHID):
+        if os.environ.get(NITROKEY_FORCE_CCID):
+            logger.warning(
+                f"Both {NITROKEY_FORCE_CTAPHID} and {NITROKEY_FORCE_CCID} are set; "
+                f"{NITROKEY_FORCE_CTAPHID} takes priority"
+            )
         return False
     if os.environ.get(NITROKEY_FORCE_CCID):
         return True

--- a/nitrokeyapp/utils.py
+++ b/nitrokeyapp/utils.py
@@ -10,16 +10,17 @@ if TYPE_CHECKING:
     from PySide6.QtWidgets import QWidget
 
 NITROKEY_FORCE_CCID = "NITROKEY_FORCE_CCID"
+NITROKEY_FORCE_CTAPHID = "NITROKEY_FORCE_CTAPHID"
 
 logger = logging.getLogger(__name__)
 
 
 def should_use_ccid() -> bool:
-    force_ccid = os.environ.get(NITROKEY_FORCE_CCID)
-    if force_ccid:
+    if os.environ.get(NITROKEY_FORCE_CTAPHID):
+        return False
+    if os.environ.get(NITROKEY_FORCE_CCID):
         return True
-    else:
-        return should_default_ccid()
+    return should_default_ccid()
 
 
 def check_ccid_config(parent: Optional["QWidget"] = None) -> None:


### PR DESCRIPTION
- Add `NITROKEY_FORCE_CTAPHID` env var to force CTAPHID communication (Issue #420)
- Expose PIN/Touch options for HMAC credentials (Issue #330)
- Fix clipboard clear race condition (PR correction #442)
