### PR TITLE
Added more passkey metadata

### DIFF
--- a/nitrokeyapp/fido2_tab/__init__.py
+++ b/nitrokeyapp/fido2_tab/__init__.py
@@ -94,17 +94,18 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.comment_label.setText("Credential ID:")
         self.ui.comment.setReadOnly(True)
 
-        # secrets_tab.ui is shared with the Secrets tab, so these layouts are not
-        # ours to rely on: if they are ever renamed, degrade to hiding the extra
-        # metadata instead of breaking the whole tab.
-        # show the credential's signature algorithm as an extra detail row
+        # secrets_tab.ui is shared with the Secrets tab (if they are ever renamed, degrade to hiding the extra)
+        # show the credential's signature algorithm and protection policy as extra detail rows
         self.algorithm_value = QLabel(self.ui)
         self.algorithm_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.cred_protect_value = QLabel(self.ui)
+        self.cred_protect_value.setWordWrap(True)
         form_layout = self.ui.findChild(QFormLayout, "formLayout")
         if form_layout is not None:
             form_layout.addRow("Algorithm:", self.algorithm_value)
+            form_layout.addRow("Protection:", self.cred_protect_value)
         else:
-            logger.warning("fido2: formLayout not found, hiding algorithm row")
+            logger.warning("fido2: formLayout not found, hiding algorithm/protection rows")
 
         # show the number of stored/remaining passkey slots next to Refresh
         self.credential_count = QLabel(self.ui)
@@ -230,6 +231,7 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.password.setText(credential.user_name or "")
         self.ui.comment.setText(credential.credential_id.hex())
         self.algorithm_value.setText(credential.algorithm_label or "(unknown)")
+        self.cred_protect_value.setText(credential.cred_protect_label or "(not set)")
 
         self.ui.btn_delete.show()
 

--- a/nitrokeyapp/fido2_tab/__init__.py
+++ b/nitrokeyapp/fido2_tab/__init__.py
@@ -2,14 +2,22 @@ import logging
 
 from nitrokey.trussed import Model
 from PySide6.QtCore import Qt, QThread, Signal, Slot
-from PySide6.QtWidgets import QLineEdit, QListWidgetItem, QMessageBox, QWidget
+from PySide6.QtWidgets import (
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidgetItem,
+    QMessageBox,
+    QWidget,
+)
 
 from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
 from nitrokeyapp.worker import Worker
 
-from .data import Fido2Credential
+from .data import Fido2Credential, Fido2ListState
 from .worker import Fido2Worker
 
 logger = logging.getLogger(__name__)
@@ -86,6 +94,26 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.comment_label.setText("Credential ID:")
         self.ui.comment.setReadOnly(True)
 
+        # secrets_tab.ui is shared with the Secrets tab, so these layouts are not
+        # ours to rely on: if they are ever renamed, degrade to hiding the extra
+        # metadata instead of breaking the whole tab.
+        # show the credential's signature algorithm as an extra detail row
+        self.algorithm_value = QLabel(self.ui)
+        self.algorithm_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        form_layout = self.ui.findChild(QFormLayout, "formLayout")
+        if form_layout is not None:
+            form_layout.addRow("Algorithm:", self.algorithm_value)
+        else:
+            logger.warning("fido2: formLayout not found, hiding algorithm row")
+
+        # show the number of stored/remaining passkey slots next to Refresh
+        self.credential_count = QLabel(self.ui)
+        button_row = self.ui.findChild(QHBoxLayout, "horizontalLayout")
+        if button_row is not None:
+            button_row.insertWidget(1, self.credential_count)
+        else:
+            logger.warning("fido2: horizontalLayout not found, hiding passkey count")
+
     @property
     def title(self) -> str:
         return "Passkeys"
@@ -105,6 +133,7 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
 
     def reset_ui(self) -> None:
         self.ui.secrets_list.clear()
+        self.credential_count.clear()
         self.show_compatible(True)
         self.hide_credential()
 
@@ -143,13 +172,16 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
             return
         self.trigger_refresh_credentials.emit(self.data)
 
-    @Slot(list)
-    def credentials_listed(self, credentials: list) -> None:
+    @Slot(object)
+    def credentials_listed(self, state: Fido2ListState) -> None:
         self.ui.secrets_list.clear()
         self.hide_credential()
-        for credential in credentials:
+        for credential in state.credentials:
             self.add_credential(credential)
         self.ui.secrets_list.sortItems()
+        # summary is None when the metadata was never read (e.g. PIN aborted);
+        # keep the label empty rather than claiming "0 stored"
+        self.credential_count.setText(state.summary or "")
 
     def add_credential(self, credential: Fido2Credential) -> QListWidgetItem:
         item = QListWidgetItem(credential.display)
@@ -197,6 +229,7 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.username.setText(credential.user_display_name or "")
         self.ui.password.setText(credential.user_name or "")
         self.ui.comment.setText(credential.credential_id.hex())
+        self.algorithm_value.setText(credential.algorithm_label or "(unknown)")
 
         self.ui.btn_delete.show()
 

--- a/nitrokeyapp/fido2_tab/__init__.py
+++ b/nitrokeyapp/fido2_tab/__init__.py
@@ -4,11 +4,12 @@ from nitrokey.trussed import Model
 from PySide6.QtCore import Qt, QThread, Signal, Slot
 from PySide6.QtWidgets import (
     QFormLayout,
-    QHBoxLayout,
+    QGridLayout,
     QLabel,
     QLineEdit,
     QListWidgetItem,
     QMessageBox,
+    QSizePolicy,
     QWidget,
 )
 
@@ -94,26 +95,32 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.comment_label.setText("Credential ID:")
         self.ui.comment.setReadOnly(True)
 
-        # secrets_tab.ui is shared with the Secrets tab (if they are ever renamed, degrade to hiding the extra)
-        # show the credential's signature algorithm and protection policy as extra detail rows
         self.algorithm_value = QLabel(self.ui)
         self.algorithm_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         self.cred_protect_value = QLabel(self.ui)
         self.cred_protect_value.setWordWrap(True)
         form_layout = self.ui.findChild(QFormLayout, "formLayout")
         if form_layout is not None:
+            for i in range(form_layout.count()):
+                spacer = form_layout.itemAt(i).spacerItem()
+                if spacer is not None:
+                    spacer.changeSize(
+                        0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+                    )
+            form_layout.invalidate()
             form_layout.addRow("Algorithm:", self.algorithm_value)
             form_layout.addRow("Protection:", self.cred_protect_value)
         else:
             logger.warning("fido2: formLayout not found, hiding algorithm/protection rows")
 
-        # show the number of stored/remaining passkey slots next to Refresh
         self.credential_count = QLabel(self.ui)
-        button_row = self.ui.findChild(QHBoxLayout, "horizontalLayout")
-        if button_row is not None:
-            button_row.insertWidget(1, self.credential_count)
+        grid = self.ui.findChild(QGridLayout, "gridLayout")
+        if grid is not None:
+            grid.addWidget(
+                self.credential_count, 1, 0, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop
+            )
         else:
-            logger.warning("fido2: horizontalLayout not found, hiding passkey count")
+            logger.warning("fido2: gridLayout not found, hiding passkey count")
 
     @property
     def title(self) -> str:
@@ -174,7 +181,8 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.trigger_refresh_credentials.emit(self.data)
 
     @Slot(object)
-    def credentials_listed(self, state: Fido2ListState) -> None:
+    def credentials_listed(self, state: object) -> None:
+        assert isinstance(state, Fido2ListState)
         self.ui.secrets_list.clear()
         self.hide_credential()
         for credential in state.credentials:

--- a/nitrokeyapp/fido2_tab/data.py
+++ b/nitrokeyapp/fido2_tab/data.py
@@ -1,4 +1,20 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+# COSE algorithm identifiers -> human readable names
+# see https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+COSE_ALGORITHMS = {
+    -7: "ES256",
+    -8: "EdDSA",
+    -35: "ES384",
+    -36: "ES512",
+    -37: "PS256",
+    -38: "PS384",
+    -39: "PS512",
+    -257: "RS256",
+    -258: "RS384",
+    -259: "RS512",
+    -65535: "RS1",
+}
 
 
 @dataclass
@@ -9,6 +25,7 @@ class Fido2Credential:
     user_name: str | None
     user_display_name: str | None
     credential_id: bytes
+    algorithm: int | None = None
 
     @property
     def rp_label(self) -> str:
@@ -19,5 +36,41 @@ class Fido2Credential:
         return self.user_display_name or self.user_name or "(no name)"
 
     @property
+    def algorithm_label(self) -> str | None:
+        if self.algorithm is None:
+            return None
+        return COSE_ALGORITHMS.get(self.algorithm, str(self.algorithm))
+
+    @property
     def display(self) -> str:
         return f"{self.rp_label}: {self.user_label}"
+
+
+@dataclass
+class Fido2ListState:
+    """Result of listing credentials, including device-wide slot metadata.
+
+    ``valid`` is only set once the device metadata has actually been read; an
+    aborted PIN entry yields the default (invalid) state so the UI can tell
+    "no passkeys" apart from "we never got to look".
+    """
+
+    credentials: list[Fido2Credential] = field(default_factory=list)
+    existing_count: int = 0
+    remaining_count: int | None = None
+    valid: bool = False
+
+    @property
+    def summary(self) -> str | None:
+        """Short human-readable slot summary, or ``None`` when unknown.
+
+        ``remaining_count`` is the authenticator's *maximum possible* remaining
+        resident credentials; the real number can be lower depending on the
+        algorithm of future keys, so it is shown as an upper bound ("up to N").
+        """
+        if not self.valid:
+            return None
+        parts = [f"{self.existing_count} stored"]
+        if self.remaining_count is not None:
+            parts.append(f"up to {self.remaining_count} free")
+        return "Passkeys: " + ", ".join(parts)

--- a/nitrokeyapp/fido2_tab/data.py
+++ b/nitrokeyapp/fido2_tab/data.py
@@ -80,8 +80,8 @@ class Fido2ListState:
         """Short human-readable slot summary, or ``None`` when unknown.
 
         ``remaining_count`` is the authenticator's *maximum possible* remaining
-        resident credentials; the real number can be lower depending on the
-        algorithm of future keys, so it is shown as an upper bound ("up to N").
+        resident credentials, the real number can be lower depending on the
+        algorithm of future keys, so it is shown as an upper bound.
         """
         if not self.valid:
             return None

--- a/nitrokeyapp/fido2_tab/data.py
+++ b/nitrokeyapp/fido2_tab/data.py
@@ -16,6 +16,14 @@ COSE_ALGORITHMS = {
     -65535: "RS1",
 }
 
+# credProtect policy values -> human readable names
+# see CTAP 2.1, "Credential Protection (credProtect)"
+CRED_PROTECT_POLICIES = {
+    1: "User verification optional",
+    2: "User verification optional (with credential list)",
+    3: "User verification required",
+}
+
 
 @dataclass
 class Fido2Credential:
@@ -26,6 +34,7 @@ class Fido2Credential:
     user_display_name: str | None
     credential_id: bytes
     algorithm: int | None = None
+    cred_protect: int | None = None
 
     @property
     def rp_label(self) -> str:
@@ -40,6 +49,12 @@ class Fido2Credential:
         if self.algorithm is None:
             return None
         return COSE_ALGORITHMS.get(self.algorithm, str(self.algorithm))
+
+    @property
+    def cred_protect_label(self) -> str | None:
+        if self.cred_protect is None:
+            return None
+        return CRED_PROTECT_POLICIES.get(self.cred_protect, str(self.cred_protect))
 
     @property
     def display(self) -> str:

--- a/nitrokeyapp/fido2_tab/worker.py
+++ b/nitrokeyapp/fido2_tab/worker.py
@@ -14,10 +14,53 @@ from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
 from nitrokeyapp.worker import Job, Worker
 
-from .data import Fido2Credential
+from .data import Fido2Credential, Fido2ListState
 from .ui import Fido2PinUi, Fido2PinUiConnection
 
 logger = logging.getLogger(__name__)
+
+# COSE key parameter label 3 holds the signature algorithm identifier
+# (RFC 9052, "Key Object Parameters")
+COSE_KEY_ALG_LABEL = 3
+
+
+def build_fido2_list_state(cred_mgmt: CredentialManagement) -> Fido2ListState:
+    """Read slot metadata and enumerate all resident credentials.
+
+    Kept free of any device/UI handling so it can be exercised directly in
+    tests against a stub credential-management object.
+    """
+    metadata = cred_mgmt.get_metadata()
+    # `or 0` guards against a device reporting the key with an empty value,
+    # which would otherwise surface as "Passkeys: None stored"
+    existing = metadata.get(CredentialManagement.RESULT.EXISTING_CRED_COUNT) or 0
+    remaining = metadata.get(CredentialManagement.RESULT.MAX_REMAINING_COUNT)
+    state = Fido2ListState(existing_count=existing, remaining_count=remaining, valid=True)
+    if existing == 0:
+        return state
+
+    for rp_result in cred_mgmt.enumerate_rps():
+        rp = rp_result.get(CredentialManagement.RESULT.RP) or {}
+        rp_hash = rp_result.get(CredentialManagement.RESULT.RP_ID_HASH)
+        rp_id = rp.get("id", "(unknown)")
+        rp_name = rp.get("name")
+
+        for cred in cred_mgmt.enumerate_creds(rp_hash):
+            cid = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID) or {}
+            user = cred.get(CredentialManagement.RESULT.USER) or {}
+            public_key = cred.get(CredentialManagement.RESULT.PUBLIC_KEY) or {}
+            state.credentials.append(
+                Fido2Credential(
+                    rp_id=rp_id,
+                    rp_name=rp_name,
+                    user_id=user.get("id", b""),
+                    user_name=user.get("name"),
+                    user_display_name=user.get("displayName"),
+                    credential_id=cid.get("id", b""),
+                    algorithm=public_key.get(COSE_KEY_ALG_LABEL),
+                )
+            )
+    return state
 
 
 @dataclass
@@ -73,7 +116,7 @@ class CheckDeviceJob(Job):
 
 
 class ListCredentialsJob(Job):
-    credentials_listed = Signal(list)
+    credentials_listed = Signal(object)
 
     def __init__(
         self, common_ui: CommonUi, pin_cache: PinCache, pin_ui: Fido2PinUi, data: DeviceData
@@ -103,7 +146,7 @@ class ListCredentialsJob(Job):
             return
 
         self._pin_ui_conn = self.pin_ui.connect_actions(
-            self._on_pin, lambda: self.credentials_listed.emit([])
+            self._on_pin, lambda: self.credentials_listed.emit(Fido2ListState())
         )
         self.pin_ui.query.emit(retries)
 
@@ -125,7 +168,7 @@ class ListCredentialsJob(Job):
 
     def _do_list(self, pin: str, pin_was_queried: bool = False) -> None:
         try:
-            credentials = self._enumerate(pin)
+            state = self._enumerate(pin)
         except CtapError as e:
             self.pin_cache.clear()
             self.trigger_error(f"FIDO2 PIN authentication failed: {e}")
@@ -137,41 +180,15 @@ class ListCredentialsJob(Job):
         if pin_was_queried:
             self.pin_cache.update(self.data, pin)
 
-        self.credentials_listed.emit(credentials)
+        self.credentials_listed.emit(state)
 
-    def _enumerate(self, pin: str) -> list[Fido2Credential]:
+    def _enumerate(self, pin: str) -> Fido2ListState:
         with self.data.open() as device:
             ctap2 = Ctap2(device.device)
             client_pin = ClientPin(ctap2)
             token = client_pin.get_pin_token(pin, permissions=ClientPin.PERMISSION.CREDENTIAL_MGMT)
             cred_mgmt = CredentialManagement(ctap2, client_pin.protocol, token)
-
-            metadata = cred_mgmt.get_metadata()
-            existing = metadata.get(CredentialManagement.RESULT.EXISTING_CRED_COUNT, 0)
-            if existing == 0:
-                return []
-
-            credentials: list[Fido2Credential] = []
-            for rp_result in cred_mgmt.enumerate_rps():
-                rp = rp_result.get(CredentialManagement.RESULT.RP) or {}
-                rp_hash = rp_result.get(CredentialManagement.RESULT.RP_ID_HASH)
-                rp_id = rp.get("id", "(unknown)")
-                rp_name = rp.get("name")
-
-                for cred in cred_mgmt.enumerate_creds(rp_hash):
-                    cid = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID) or {}
-                    user = cred.get(CredentialManagement.RESULT.USER) or {}
-                    credentials.append(
-                        Fido2Credential(
-                            rp_id=rp_id,
-                            rp_name=rp_name,
-                            user_id=user.get("id", b""),
-                            user_name=user.get("name"),
-                            user_display_name=user.get("displayName"),
-                            credential_id=cid.get("id", b""),
-                        )
-                    )
-            return credentials
+            return build_fido2_list_state(cred_mgmt)
 
 
 class DeleteCredentialJob(Job):
@@ -260,7 +277,7 @@ class DeleteCredentialJob(Job):
 
 
 class Fido2Worker(Worker):
-    credentials_listed = Signal(list)
+    credentials_listed = Signal(object)
     credential_deleted = Signal(object)
     device_checked = Signal(bool)
 

--- a/nitrokeyapp/fido2_tab/worker.py
+++ b/nitrokeyapp/fido2_tab/worker.py
@@ -58,6 +58,7 @@ def build_fido2_list_state(cred_mgmt: CredentialManagement) -> Fido2ListState:
                     user_display_name=user.get("displayName"),
                     credential_id=cid.get("id", b""),
                     algorithm=public_key.get(COSE_KEY_ALG_LABEL),
+                    cred_protect=cred.get(CredentialManagement.RESULT.CRED_PROTECT),
                 )
             )
     return state


### PR DESCRIPTION
- Shows passkey slot usage next to the "Refresh" button (`Passkeys: N stored, up to M free`)
- Adds two detail rows per credential: the signature algorithm taken from the credential's COSE public key and the protection policy read from `CRED_PROTECT`
- Falls back to the raw number for unknown algorithm or policy IDs and shows `(unknown)` or `(not set)` when a value is missing


https://www.iana.org/assignments/cose/cose.xhtml#algorithms

https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension
