### PR TITLE
OS logfile cleanup

### DIFF
--- a/nitrokeyapp/logger.py
+++ b/nitrokeyapp/logger.py
@@ -1,13 +1,15 @@
 import logging
+import logging.handlers
 import os
 import platform
 import shutil
 import sys
+import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
 from importlib.metadata import version as package_version
-from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 from PySide6.QtWidgets import QFileDialog, QWidget
 
@@ -15,14 +17,29 @@ logger = logging.getLogger(__name__)
 
 log_to_console = "NKAPP_LOG" in os.environ
 
+LOG_FILE_NAME = "nitrokey-app2.log"
+LOG_FILE_BACKUP_COUNT = 9
+
 
 @contextmanager
 def init_logging() -> Generator[str, None, None]:
-    log_file = NamedTemporaryFile(prefix="nitrokey-app2.", suffix=".log", delete=False)
+    log_file = Path(tempfile.gettempdir()) / LOG_FILE_NAME
     log_format = "%(relativeCreated)-8d %(levelname)6s %(name)10s %(message)s"
 
     try:
-        handler = logging.FileHandler(filename=log_file.name, delay=True, encoding="utf-8")
+        handler = logging.handlers.RotatingFileHandler(
+            filename=log_file, backupCount=LOG_FILE_BACKUP_COUNT, delay=True, encoding="utf-8"
+        )
+        try:
+            handler.doRollover()
+        except OSError:
+            pass
+
+        try:
+            os.close(os.open(log_file, os.O_CREAT | os.O_WRONLY, 0o600))
+        except OSError:
+            pass
+
         console_handler = logging.StreamHandler(sys.stdout)
 
         handlers = [handler]
@@ -31,7 +48,7 @@ def init_logging() -> Generator[str, None, None]:
 
         logging.basicConfig(format=log_format, level=logging.DEBUG, handlers=handlers)
 
-        yield log_file.name
+        yield str(log_file)
     finally:
         logging.shutdown()
 
@@ -51,7 +68,10 @@ def log_environment() -> None:
 def save_log(log_file: str, parent: QWidget) -> None:
     path, _ = QFileDialog.getSaveFileName(parent, "Save Log File")
     if path:
-        logger = logging.getLogger()
-        for handler in logger.handlers:
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers:
             handler.flush()
-        shutil.copyfile(log_file, path)
+        try:
+            shutil.copyfile(log_file, path)
+        except OSError as e:
+            logger.error(f"failed to save the logfile: {e}")


### PR DESCRIPTION
- use `RotatingFileHandler` for one logfile per run (last 10 kept on all platforms)
- roll over at startup because `maxBytes` is 0 and it would never rotate
- create the logfile up front, readable by the current user only
- do not crash in `save_log` if the logfile is gone
