### PR TITLE
Factory resetting the Passwords tab

### DIFF
--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -110,6 +110,8 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
             self.fido2_tab,
             self.settings_tab,
         ]
+
+        self.settings_tab._worker.reset_passwords.connect(self.secrets_tab.invalidate)
         self.busy_count = 0
         for view in self.views:
             if view.worker:

--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -244,6 +244,18 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         self.reset_ui()
 
+    @Slot()
+    def invalidate(self) -> None:
+        """Drop cached credentials so the next refresh reloads from the device.
+
+        Used after an external change to the passwords app (e.g. a factory
+        reset from the Settings tab) that this tab cannot observe directly.
+        """
+        self.active_credential = None
+        self._worker.pin_cache.clear()
+        self.data = None
+        self.reset_ui()
+
     def reset_ui(self) -> None:
         self.ui.secrets_list.clear()
 
@@ -255,8 +267,8 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.page_incompatible.setVisible(not show)
         self.hide_credential()
 
-    def refresh(self, data: DeviceData) -> None:
-        if data == self.data:
+    def refresh(self, data: DeviceData, force: bool = False) -> None:
+        if data == self.data and not force:
             return
         self.data = data
         self._worker.pin_cache.clear()


### PR DESCRIPTION
- Fixed the bug where the Passwords tab still showed old credentials after a factory reset (issue #437)
- Added an `invalidate()` method to the Passwords tab that clears its cached credentials and PIN cache
- Also connected the Settings tab password reset signal to that method so the list reloads the next time you open the tab
- Added the missing `force` parameter to the Passwords tab's `refresh()` so it matches the other tabs (this one I guessed was intended tbh based on the other tabs)
