### PR TITLE
fix OTP issues in nitrokeyapp

### DIFF
--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -3,7 +3,7 @@ import logging
 import string
 from base64 import b32decode, b32encode
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from random import randbytes
 from secrets import choice
@@ -119,6 +119,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.data: DeviceData | None = None
         self.active_credential: Credential | None = None
 
+        self.period: int = 0
         self.otp_timeout: datetime | None = None
         self.otp_timer = QTimer()
         self.otp_timer.timeout.connect(self.update_otp_timeout)
@@ -334,9 +335,9 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         if data.validity:
             start, end = data.validity
             period = int((end - start).total_seconds())
-            self.ui.otp_timeout_progress.setMaximum(period + period)
-
-            self.otp_timeout = end + (end - start)
+            self.period = period
+            self.ui.otp_timeout_progress.setMaximum(period)
+            self.otp_timeout = end
             self.otp_timer.start()
             self.update_otp_timeout()
 
@@ -888,6 +889,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.otp_timer.stop()
         self.ui.otp_timeout_progress.hide()
         self.ui.otp.clear()
+        self.ui.otp.setPlaceholderText("<hidden>")
 
     @Slot()
     def update_otp_timeout(self) -> None:
@@ -895,7 +897,10 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         if not self.otp_timeout:
             return
         timeout = int((self.otp_timeout - datetime.now()).total_seconds())
-        if timeout >= 0:
+        hidden_timeout = int(
+            (self.otp_timeout + timedelta(seconds=self.period) - datetime.now()).total_seconds()
+        )
+        if hidden_timeout >= 0:
             self.ui.otp_timeout_progress.setValue(timeout)
         else:
             self.hide_otp()

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -519,6 +519,8 @@ class GenerateOtpJob(Job):
                 self.trigger_exception(e)
                 return
 
+            print("Validity ", validity)
+
             self.otp_generated.emit(OtpData(otp, validity))
 
 

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -518,9 +518,6 @@ class GenerateOtpJob(Job):
             except SecretsAppException as e:
                 self.trigger_exception(e)
                 return
-
-            print("Validity ", validity)
-
             self.otp_generated.emit(OtpData(otp, validity))
 
 

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -518,6 +518,7 @@ class GenerateOtpJob(Job):
             except SecretsAppException as e:
                 self.trigger_exception(e)
                 return
+                
             self.otp_generated.emit(OtpData(otp, validity))
 
 

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -518,7 +518,7 @@ class GenerateOtpJob(Job):
             except SecretsAppException as e:
                 self.trigger_exception(e)
                 return
-                
+
             self.otp_generated.emit(OtpData(otp, validity))
 
 


### PR DESCRIPTION
Fixed the issues 

- the progress bar should show only the actual period and count-down
- the TOTP should be shown for double the duration (so 30secs longer after the progress bar finished)
- correct the message shown in the entry-field after the duration has passed and the OTP is cleard, it now shows "OTP not configured"

Importing OTPs from URI not yet added. 