### PR TITLE
Added a command line interface

### DIFF
--- a/nitrokeyapp/__main__.py
+++ b/nitrokeyapp/__main__.py
@@ -4,10 +4,14 @@ from contextlib import contextmanager
 from types import TracebackType
 from typing import Any
 
+import click
 from PySide6 import QtWidgets
 
+from nitrokeyapp import __version__
 from nitrokeyapp.gui import GUI
 from nitrokeyapp.logger import init_logging, log_environment
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "ignore_unknown_options": True}
 
 
 @contextmanager
@@ -22,8 +26,8 @@ def exception_handler(
         sys.excepthook = old_hook
 
 
-def main() -> None:
-    app = QtWidgets.QApplication(sys.argv)
+def run_gui(argv: list[str]) -> None:
+    app = QtWidgets.QApplication(argv)
     app.setDesktopFileName("com.nitrokey.nitrokey-app2")
 
     with init_logging() as log_file:
@@ -32,6 +36,18 @@ def main() -> None:
         window = GUI(app, log_file)
         with exception_handler(window.trigger_handle_exception.emit):
             app.exec()
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.version_option(__version__, "-V", "--version")
+@click.argument("qt_args", nargs=-1, type=click.UNPROCESSED)
+def main(qt_args: tuple[str, ...]) -> None:
+    """Graphical application to manage Nitrokey devices.
+
+    Without arguments the graphical user interface is started. Any additional
+    arguments are passed on to Qt, for example: -platform offscreen
+    """
+    run_gui([sys.argv[0], *qt_args])
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,6 +221,34 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["main"]
+markers = "platform_system == \"Windows\""
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "crcmod"
 version = "1.7"
 description = "CRC Generator"
@@ -1179,4 +1207,4 @@ pcsc = ["nitrokey"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "d27f697c98ed1b602dde13a98a2bb8cdcde88bf8f7c75406e19471adc6299abf"
+content-hash = "f3608de6ca7ab419a5238f4643af1361f253b6cadf6f19fe2518599ae3ee54a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
+click = "^8"
 fido2 = "^2"
 nitrokey = "=0.5.0-rc.2"
 pySide6 = ">=6.6.0"


### PR DESCRIPTION
- add a Click based CLI with --version and --help
- handle both options before QApplication is created, so they also work without a display
- import Qt and the GUI lazily in run_gui()
- pass any further arguments on to Qt