### PR TITLE
Worker error handling: recover from failures, log actions

### DIFF
--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -64,14 +64,13 @@ class CheckDeviceJob(Job):
         compatible = False
         try:
             with self.data.open() as device:
-                if not isinstance(device, NK3):
-                    return
-                secrets = SecretsApp(device)
-                try:
-                    compatible = secrets._semver_equal_or_newer("4.11.0")
-                except Exception:
-                    # TODO: catch a more specific exception
-                    pass
+                if isinstance(device, NK3):
+                    secrets = SecretsApp(device)
+                    try:
+                        compatible = secrets._semver_equal_or_newer("4.11.0")
+                    except Exception:
+                        # TODO: catch a more specific exception
+                        pass
         except Exception as e:
             logger.info(f"check device job failed: {e}")
             compatible = False
@@ -115,6 +114,7 @@ class VerifyPinJob(Job):
     def run(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             select = secrets.select()
@@ -134,6 +134,7 @@ class VerifyPinJob(Job):
     def pin_queried(self, pin: str) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             try:
@@ -151,6 +152,7 @@ class VerifyPinJob(Job):
     def pin_chosen(self, pin: str) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -298,6 +300,7 @@ class EditCredentialJob(Job):
     def edit_credential_final(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -380,6 +383,7 @@ class AddCredentialJob(Job):
 
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -447,6 +451,7 @@ class DeleteCredentialJob(Job):
     def delete_credential(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             try:
@@ -492,6 +497,7 @@ class GenerateOtpJob(Job):
     def generate_otp(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
 
@@ -548,6 +554,7 @@ class ListCredentialsJob(Job):
         else:
             with self.data.open() as device:
                 if not isinstance(device, NK3):
+                    self.trigger_error("This device does not support Passwords")
                     return
                 secrets = SecretsApp(device)
                 credentials = Credential.list(secrets)
@@ -561,6 +568,7 @@ class ListCredentialsJob(Job):
 
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             for credential in Credential.list(secrets):
@@ -604,6 +612,7 @@ class GetCredentialJob(Job):
     def get_credential(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             try:

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -164,6 +164,7 @@ class VerifyPinJob(Job):
 
     @Slot(str)
     def trigger_error(self, msg: str) -> None:
+        logger.error(f"{self.__class__.__name__} failed: {msg}")
         self.common_ui.info.error.emit(msg)
         self.pin_verified.emit(False)
 

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -262,7 +262,6 @@ class EditCredentialJob(Job):
         self.credential = credential
         self.delete_credential(delete_id)
 
-    @Slot()
     def delete_credential(self, cred_id: bytes) -> None:
         cred = Credential(
             id=cred_id,
@@ -280,7 +279,6 @@ class EditCredentialJob(Job):
         # drop credential
         self.credential_edited.emit(self.credential)
 
-    @Slot()
     def temp_rename_credential(self, from_cred_id: bytes) -> bytes:
         new_cred_id = b"__" + from_cred_id
         assert self.all_credentials

--- a/nitrokeyapp/settings_tab/worker.py
+++ b/nitrokeyapp/settings_tab/worker.py
@@ -144,6 +144,7 @@ class SavePasswordsPinJob(Job):
 
     @Slot(str)
     def trigger_error(self, msg: str) -> None:
+        logger.error(f"{self.__class__.__name__} failed: {msg}")
         self.common_ui.info.error.emit(msg)
 
 

--- a/nitrokeyapp/settings_tab/worker.py
+++ b/nitrokeyapp/settings_tab/worker.py
@@ -52,6 +52,7 @@ class CheckPasswordsInfo(Job):
         pin_status: bool = False
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             status = secrets.select()
@@ -129,16 +130,17 @@ class SavePasswordsPinJob(Job):
         with self.touch_prompt():
             with self.data.open() as device:
                 if not isinstance(device, NK3):
-                    return
-                secrets = SecretsApp(device)
-                try:
-                    if passwords_state:
-                        secrets.change_pin_raw(self.old_pin, self.new_pin)
-                    else:
-                        secrets.set_pin_raw(self.new_pin)
-                    self.common_ui.info.info.emit("Passwords PIN changed!")
-                except SecretsAppException as e:
-                    self.trigger_error(f"PIN validation failed: {e}")
+                    self.trigger_error("This device does not support Passwords")
+                else:
+                    secrets = SecretsApp(device)
+                    try:
+                        if passwords_state:
+                            secrets.change_pin_raw(self.old_pin, self.new_pin)
+                        else:
+                            secrets.set_pin_raw(self.new_pin)
+                        self.common_ui.info.info.emit("Passwords PIN changed!")
+                    except SecretsAppException as e:
+                        self.trigger_error(f"PIN validation failed: {e}")
 
         self.change_pw_passwords.emit()
 
@@ -190,6 +192,7 @@ class ResetPasswords(Job):
     def run(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             try:

--- a/nitrokeyapp/worker.py
+++ b/nitrokeyapp/worker.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Job(QObject):
     finished = Signal()
+    failed = Signal()
 
     def __init__(self, common_ui: CommonUi) -> None:
         super().__init__()
@@ -34,16 +35,24 @@ class Job(QObject):
     def trigger_error(self, msg: str) -> None:
         logger.error(f"{self.__class__.__name__} failed: {msg}")
         self.common_ui.info.error.emit(f"{self.__class__.__name__}: {msg}")
+        self.failed.emit()
         self.finished.emit()
 
     @Slot(Exception)
     def trigger_exception(self, exc: Exception) -> None:
         logger.error(f"{self.__class__.__name__} raised: {exc}", exc_info=exc)
         self.common_ui.info.error.emit(f"{self.__class__.__name__}: {exc}")
+        self.failed.emit()
         self.finished.emit()
 
     def spawn(self, job: "Job") -> None:
+        job.failed.connect(self.propagate_failure)
         job.run()
+
+    @Slot()
+    def propagate_failure(self) -> None:
+        self.failed.emit()
+        self.finished.emit()
 
     @contextmanager
     def touch_prompt(self) -> Generator[None, None, None]:
@@ -67,4 +76,7 @@ class Worker(QObject):
         self.busy_state_changed.emit(True)
 
         job.finished.connect(lambda: self.busy_state_changed.emit(False))
-        job.run()
+        try:
+            job.run()
+        except Exception as e:
+            job.trigger_exception(e)

--- a/nitrokeyapp/worker.py
+++ b/nitrokeyapp/worker.py
@@ -1,9 +1,12 @@
+import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 
 from PySide6.QtCore import QObject, Signal, Slot
 
 from nitrokeyapp.common_ui import CommonUi
+
+logger = logging.getLogger(__name__)
 
 # TODO: DeviceJob
 # - connection management
@@ -29,11 +32,13 @@ class Job(QObject):
 
     @Slot(str)
     def trigger_error(self, msg: str) -> None:
+        logger.error(f"{self.__class__.__name__} failed: {msg}")
         self.common_ui.info.error.emit(self.__class__.__name__ + str(Exception(msg)))
         self.finished.emit()
 
     @Slot(Exception)
     def trigger_exception(self, exc: Exception) -> None:
+        logger.error(f"{self.__class__.__name__} raised: {exc}", exc_info=exc)
         self.common_ui.info.error.emit(self.__class__.__name__ + str(exc))
         self.finished.emit()
 
@@ -58,6 +63,7 @@ class Worker(QObject):
         self.common_ui = owner_common_ui
 
     def run(self, job: Job) -> None:
+        logger.info(f"{self.__class__.__name__} starting {job.__class__.__name__}")
         self.busy_state_changed.emit(True)
 
         job.finished.connect(lambda: self.busy_state_changed.emit(False))

--- a/nitrokeyapp/worker.py
+++ b/nitrokeyapp/worker.py
@@ -33,13 +33,13 @@ class Job(QObject):
     @Slot(str)
     def trigger_error(self, msg: str) -> None:
         logger.error(f"{self.__class__.__name__} failed: {msg}")
-        self.common_ui.info.error.emit(self.__class__.__name__ + str(Exception(msg)))
+        self.common_ui.info.error.emit(f"{self.__class__.__name__}: {msg}")
         self.finished.emit()
 
     @Slot(Exception)
     def trigger_exception(self, exc: Exception) -> None:
         logger.error(f"{self.__class__.__name__} raised: {exc}", exc_info=exc)
-        self.common_ui.info.error.emit(self.__class__.__name__ + str(exc))
+        self.common_ui.info.error.emit(f"{self.__class__.__name__}: {exc}")
         self.finished.emit()
 
     def spawn(self, job: "Job") -> None:


### PR DESCRIPTION
- **Logging.** `Worker.run` is the single dispatch point for every device action, so one line there covers all of them. `Job.trigger_error` / `trigger_exception` log too
- **Error box.** These two concatenated the class name and message with no separator: `ListCredentialsJobFIDO2 PIN authentication failed: ...`
- **`@Slot` signatures.** Several declared arities did not match their methods. No behaviour change

### The bug that appeared

The app can get permanently stuck in the busy state, so the spinner never stops, inputs stay disabled, no error is shown, and there is no way back except for restarting

`Worker.run` emits `busy_state_changed(True)` before `job.run()`, but nothing guaranteed the matching `False`:

- exceptions escaping `job.run()` were never caught (unplug a device mid-operation)
- `if not isinstance(device, NK3): return` skipped the completion signal
- a spawned job that failed never notified its parent

Fixed with `Job.failed` (propagated through `Job.spawn`), a `try`/`except` in `Worker.run`, and an error report at each bail-out instead of a silent `return`.