### PR TITLE
Release artifact names

### DIFF
--- a/.github/workflows/cd-linux-arm64.yaml
+++ b/.github/workflows/cd-linux-arm64.yaml
@@ -75,8 +75,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-onefile
-          path: dist/nitrokey-app
+          name: nitrokey-app2-onefile
+          path: dist/nitrokey-app2
   publish-binary:
     name: Publish binary
     runs-on: ubuntu-24.04-arm
@@ -89,13 +89,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-onefile
+          name: nitrokey-app2-onefile
       - name: Rename binary
         run: |
           mv \
-            nitrokey-app \
-            nitrokey-app-${{ github.event.release.tag_name }}-arm64-linux-binary
+            nitrokey-app2 \
+            nitrokey-app2-${{ github.event.release.tag_name }}-arm64-linux-binary
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          files: nitrokey-app-${{ github.event.release.tag_name }}-arm64-linux-binary
+          files: nitrokey-app2-${{ github.event.release.tag_name }}-arm64-linux-binary

--- a/.github/workflows/cd-linux-x64.yaml
+++ b/.github/workflows/cd-linux-x64.yaml
@@ -75,8 +75,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-onefile
-          path: dist/nitrokey-app
+          name: nitrokey-app2-onefile
+          path: dist/nitrokey-app2
   publish-binary:
     name: Publish binary
     runs-on: ubuntu-latest
@@ -89,13 +89,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-onefile
+          name: nitrokey-app2-onefile
       - name: Rename binary
         run: |
           mv \
-            nitrokey-app \
-            nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary
+            nitrokey-app2 \
+            nitrokey-app2-${{ github.event.release.tag_name }}-x64-linux-binary
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          files: nitrokey-app-${{ github.event.release.tag_name }}-x64-linux-binary
+          files: nitrokey-app2-${{ github.event.release.tag_name }}-x64-linux-binary

--- a/.github/workflows/cd-macos-arm64.yaml
+++ b/.github/workflows/cd-macos-arm64.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Build onedir
         run: |
           source $(poetry env info --path)/bin/activate
-          pyinstaller ci-scripts/macOS/pyinstaller/nitrokey-app-onedir_arm64.spec
+          pyinstaller ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
       - name: Set application metadata
         run: |
           plutil \
@@ -115,7 +115,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-pkg-arm64
+          name: nitrokey-app2-pkg-arm64
           path: nitrokey-app2.pkg
   publish-pkg-installer:
     name: Publish PKG installer
@@ -128,7 +128,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-pkg-arm64
+          name: nitrokey-app2-pkg-arm64
       - name: Rename installer
         run: |
           mv \

--- a/.github/workflows/cd-macos-intel64.yaml
+++ b/.github/workflows/cd-macos-intel64.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Build onedir
         run: |
           source $(poetry env info --path)/bin/activate
-          pyinstaller ci-scripts/macOS/pyinstaller/nitrokey-app-onedir_intel64.spec
+          pyinstaller ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
       - name: Set application metadata
         run: |
           plutil \
@@ -115,7 +115,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-pkg-intel64
+          name: nitrokey-app2-pkg-intel64
           path: nitrokey-app2.pkg
   publish-pkg-installer:
     name: Publish PKG installer
@@ -128,7 +128,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-pkg-intel64
+          name: nitrokey-app2-pkg-intel64
       - name: Rename installer
         run: |
           mv \

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -53,8 +53,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-onedir-unsigned
-          path: dist/nitrokey-app
+          name: nitrokey-app2-onedir-unsigned
+          path: dist/nitrokey-app2
   sign-onedir:
     name: Sign onedir
     runs-on:
@@ -66,11 +66,11 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-onedir-unsigned
-          path: dist/nitrokey-app
+          name: nitrokey-app2-onedir-unsigned
+          path: dist/nitrokey-app2
       - name: Sign the artifact
         run: |
-          mv dist/nitrokey-app/nitrokey-app.exe nitrokey-app_unsigned.exe
+          mv dist/nitrokey-app2/nitrokey-app2.exe nitrokey-app2_unsigned.exe
           osslsigncode \
             sign \
             -provider /usr/lib/aarch64-linux-gnu/engines-3/pkcs11.so \
@@ -79,14 +79,14 @@ jobs:
             -key "${{ secrets.PKCS11_KEY_URI_WINDOWS }}" \
             -h sha256 \
             -ts "http://ts.ssl.com" \
-            -in nitrokey-app_unsigned.exe \
-            -out nitrokey-app_signed.exe
-          mv nitrokey-app_signed.exe dist/nitrokey-app/nitrokey-app.exe
+            -in nitrokey-app2_unsigned.exe \
+            -out nitrokey-app2_signed.exe
+          mv nitrokey-app2_signed.exe dist/nitrokey-app2/nitrokey-app2.exe
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-onedir-signed
-          path: dist/nitrokey-app
+          name: nitrokey-app2-onedir-signed
+          path: dist/nitrokey-app2
   build-msi-installer:
     name: Build MSI installer
     runs-on: windows-latest
@@ -98,13 +98,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-onedir-signed
-          path: dist/nitrokey-app
+          name: nitrokey-app2-onedir-signed
+          path: dist/nitrokey-app2
       - name: Create sources file
         run: |
           $Env:Path += ";" + "$Env:WIX" + "bin"
           heat `
-            dir .\dist\nitrokey-app\ `
+            dir .\dist\nitrokey-app2\ `
             -dr INSTALLFOLDER `
             -ag `
             -cg ApplicationFilesDynamic `
@@ -126,16 +126,16 @@ jobs:
         run: |
           $Env:Path += ";" + "$Env:WIX" + "bin"
           light `
-            -b .\dist\nitrokey-app\ `
+            -b .\dist\nitrokey-app2\ `
             -sice:ICE80 `
             .\Product.wixobj `
             .\Sources.wixobj `
-            -o nitrokey-app.msi
+            -o nitrokey-app2.msi
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-installer-unsigned
-          path: nitrokey-app.msi
+          name: nitrokey-app2-installer-unsigned
+          path: nitrokey-app2.msi
   sign-msi-installer:
     name: Sign MSI installer
     runs-on:
@@ -147,10 +147,10 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-installer-unsigned
+          name: nitrokey-app2-installer-unsigned
       - name: Sign the artifact
         run: |
-          mv nitrokey-app.msi nitrokey-app_unsigned.msi
+          mv nitrokey-app2.msi nitrokey-app2_unsigned.msi
           osslsigncode \
             sign \
             -provider /usr/lib/aarch64-linux-gnu/engines-3/pkcs11.so \
@@ -159,13 +159,13 @@ jobs:
             -key "${{ secrets.PKCS11_KEY_URI_WINDOWS }}" \
             -h sha256 \
             -ts "http://ts.ssl.com" \
-            -in nitrokey-app_unsigned.msi \
-            -out nitrokey-app.msi
+            -in nitrokey-app2_unsigned.msi \
+            -out nitrokey-app2.msi
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nitrokey-app-installer-signed
-          path: nitrokey-app.msi
+          name: nitrokey-app2-installer-signed
+          path: nitrokey-app2.msi
   publish-msi-installer:
     name: Publish MSI installer
     runs-on: windows-latest
@@ -177,13 +177,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: nitrokey-app-installer-signed
+          name: nitrokey-app2-installer-signed
       - name: Rename installer
         run: |
           mv `
-            nitrokey-app.msi `
-            nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-installer.msi
+            nitrokey-app2.msi `
+            nitrokey-app2-${{ github.event.release.tag_name }}-x64-windows-installer.msi
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          files: nitrokey-app-${{ github.event.release.tag_name }}-x64-windows-installer.msi
+          files: nitrokey-app2-${{ github.event.release.tag_name }}-x64-windows-installer.msi

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
@@ -41,7 +41,7 @@ exe = EXE(
     a.scripts,
     [],
     exclude_binaries=True,
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -62,5 +62,5 @@ coll = COLLECT(
     strip=False,
     upx=True,
     upx_exclude=[],
-    name='nitrokey-app',
+    name='nitrokey-app2',
 )

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
@@ -43,7 +43,7 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     [],
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
@@ -35,7 +35,7 @@ exe = EXE(
     a.scripts,
     [],
     exclude_binaries=True,
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
@@ -35,7 +35,7 @@ exe = EXE(
     a.scripts,
     [],
     exclude_binaries=True,
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
@@ -36,7 +36,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
@@ -36,7 +36,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/ci-scripts/windows/pyinstaller/file_version_info_metadata.yaml
+++ b/ci-scripts/windows/pyinstaller/file_version_info_metadata.yaml
@@ -1,8 +1,8 @@
 CompanyName: Nitrokey
 FileDescription: Graphical application to manage Nitrokey devices
-InternalName: Nitrokey-App
+InternalName: Nitrokey App 2
 LegalCopyright: Apache License
-OriginalFilename: Nitrokey-App.exe
+OriginalFilename: nitrokey-app2.exe
 ProductName: Nitrokey-App
 Translation:
   - langID: 0x0409

--- a/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
@@ -39,7 +39,7 @@ exe = EXE(
     a.scripts,
     [],
     exclude_binaries=True,
-    name='nitrokey-app',
+    name='nitrokey-app2',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -63,5 +63,5 @@ coll = COLLECT(
     strip=False,
     upx=True,
     upx_exclude=[],
-    name='nitrokey-app',
+    name='nitrokey-app2',
 )

--- a/ci-scripts/windows/wix/Product.wxs
+++ b/ci-scripts/windows/wix/Product.wxs
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*"
-        Name="Nitrokey-App"
+        Name="Nitrokey App 2"
         Language="1033"
-        Version="!(bind.FileVersion.nitrokey_app.exe)"
+        Version="!(bind.FileVersion.nitrokey_app2.exe)"
         Manufacturer="Nitrokey GmbH"
         UpgradeCode="{F928EC81-A9D6-4022-BE9B-EC35EF33444F}">
 
         <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x64" />
     
-        <MajorUpgrade DowngradeErrorMessage="A newer version of Nitrokey-App is already installed." />
+        <MajorUpgrade DowngradeErrorMessage="A newer version of Nitrokey App 2 is already installed." />
 
         <MediaTemplate EmbedCab="yes"/>
 
-        <Feature Id="ProductFeature" Title="Nitrokey-App" Level="1">
+        <Feature Id="ProductFeature" Title="Nitrokey App 2" Level="1">
             <ComponentGroupRef Id="ApplicationFiles" />
             <ComponentRef Id="ApplicationShortcut" />
             <ComponentRef Id="DesktopShortcut" />
@@ -26,7 +26,7 @@
             <!-- Application files -->
             <Directory Id="ProgramFiles64Folder">
                 <Directory Id="MANUFACTURER" Name="Nitrokey">
-                    <Directory Id="INSTALLFOLDER" Name="Nitrokey-App" />
+                    <Directory Id="INSTALLFOLDER" Name="Nitrokey App 2" />
                 </Directory>
             </Directory>
 
@@ -55,8 +55,8 @@
             <Component Id="ApplicationShortcut" Guid="*">
                 <Shortcut
                     Id="StartMenuShortcut"
-                    Name="Nitrokey-App"
-                    Target="[INSTALLFOLDER]nitrokey-app.exe"
+                    Name="Nitrokey App 2"
+                    Target="[INSTALLFOLDER]nitrokey-app2.exe"
                     WorkingDirectory="INSTALLFOLDER" />
                 <RemoveFolder
                     Id="CleanupShortcut"
@@ -79,8 +79,8 @@
            <Component Id="DesktopShortcut" Guid="*">
                <Shortcut
                    Id="ApplicationDesktopShortcut"
-                   Name="Nitrokey-App"
-                   Target="[INSTALLFOLDER]nitrokey-app.exe"
+                   Name="Nitrokey App 2"
+                   Target="[INSTALLFOLDER]nitrokey-app2.exe"
                    WorkingDirectory="INSTALLFOLDER" />
                <RemoveFolder Id="DesktopFolder" On="uninstall"/>
                <RegistryValue


### PR DESCRIPTION
- PyInstaller specs build the binary as nitrokey-app2
- Workflows updated: dist paths, artifact names, MSI name
- Product.wxs: shortcuts and version bind point at nitrokey-app2.exe
- MSI product name, install folder and shortcuts now say "Nitrokey App 2"
- InternalName and OriginalFilename updated to match
- Fixed ci-scripts/macOS/ -> ci-scripts/macos/ in the macOS workflows

Linked to: https://github.com/Nitrokey/nitrokey-app2/issues/90
