### PR TITLE
break the Nitrokey label onto two lines

### DIFF
--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -119,7 +119,7 @@ class Nk3Button(QtWidgets.QToolButton):
 
     def unfold(self) -> None:
         self.setChecked(False)
-        self.setText(self.data.name)
+        self.setText(self.data.name.replace(": ", "\n"))
         self.setMinimumWidth(178)
         self.setMaximumWidth(178)
         self.setIconSize(QtCore.QSize(32, 32))


### PR DESCRIPTION
<img width="242" height="193" alt="Screenshot 2026-08-20 225627" src="https://github.com/user-attachments/assets/af23414d-d6c3-4475-8640-e177663a0407" />
