### PR TITLE
ci: Use beta branch for flathub build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: flathub/com.nitrokey.nitrokey-app2
+        ref: beta
         path: flatpak-build
     - name: Update flathub repository to use this commit
       run: |


### PR DESCRIPTION
Unreleased changes of the app may require changes in the flathub build process. Using the beta branch for the flathub build in the CI allows us to update the build without a release. This should fix the CI after the command rename.