### PR TITLE
Add: Multi-language support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 poetry.lock linguist-generated=false
+
+# pyside6-lupdate writes LF on every platform; keep the checkout that way
+nitrokeyapp/translations/*.ts text eol=lf

--- a/.github/workflows/cd-macos-arm64.yaml
+++ b/.github/workflows/cd-macos-arm64.yaml
@@ -46,6 +46,8 @@ jobs:
         run: |
           poetry env use python${{ env.PYTHON_VERSION }}
           poetry install
+      - name: Compile translations
+        run: poetry run python ci-scripts/translations.py release
       - name: Build onedir
         run: |
           source $(poetry env info --path)/bin/activate

--- a/.github/workflows/cd-macos-intel64.yaml
+++ b/.github/workflows/cd-macos-intel64.yaml
@@ -46,6 +46,8 @@ jobs:
         run: |
           poetry env use python${{ env.PYTHON_VERSION }}
           poetry install
+      - name: Compile translations
+        run: poetry run python ci-scripts/translations.py release
       - name: Build onedir
         run: |
           source $(poetry env info --path)/bin/activate

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -41,6 +41,8 @@ jobs:
         run: poetry install
       - name: Create virtual environment
         run: poetry install --extras pcsc 
+      - name: Compile translations
+        run: poetry run python ci-scripts/translations.py release
       - name: Create Windows version info file
         run: |
           poetry run create-version-file `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,22 @@ jobs:
         run: make init
       - name: Check code static typing
         run: make check-typing
+  lint-translations:
+    name: Check translation catalogs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install required packages
+        run: pip install poetry
+      - name: Create virtual environment
+        run: make init
+      - name: Check that the catalogs match the sources
+        run: make check-translations
   lint-flatpak-metadata:
     name: Check flatpak metadata
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 nitrokeyapp/ui/*.py
+nitrokeyapp/translations/*.qm
 build/
 dist/
 variables.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean 
+.PHONY: clean translations-update translations-release check-translations
 
 -include variables.mk
 
@@ -28,15 +28,23 @@ semi-clean:
 clean: semi-clean
 	poetry env remove --all
 	rm -rf .mypy_cache
+	rm -f $(PACKAGE_NAME)/translations/*.qm
+
+# translations
+translations-update:
+	poetry run python ci-scripts/translations.py update
+
+translations-release:
+	poetry run python ci-scripts/translations.py release
 
 # build
-build:
+build: translations-release
 	poetry build
 
-build-pyinstaller-onefile:
+build-pyinstaller-onefile: translations-release
 	poetry run pyinstaller ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
 
-build-pyinstaller-onedir:
+build-pyinstaller-onedir: translations-release
 	poetry run pyinstaller ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
 
 # code checks
@@ -49,7 +57,10 @@ check-style:
 check-typing:
 	poetry run mypy $(PACKAGE_NAME)/
 
-check: check-format check-style check-typing
+check-translations:
+	poetry run python ci-scripts/translations.py check
+
+check: check-format check-style check-typing check-translations
 
 fix:
 	$(RUFF) format $(PACKAGE_NAME)/

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onedir.spec
@@ -9,6 +9,7 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
+    ('../../../nitrokeyapp/translations', 'nitrokeyapp/translations'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
+++ b/ci-scripts/linux/pyinstaller/nitrokey-app-onefile.spec
@@ -9,6 +9,7 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
+    ('../../../nitrokeyapp/translations', 'nitrokeyapp/translations'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_arm64.spec
@@ -9,6 +9,7 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
+    ('../../../nitrokeyapp/translations', 'nitrokeyapp/translations'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onedir_intel64.spec
@@ -9,6 +9,7 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
+    ('../../../nitrokeyapp/translations', 'nitrokeyapp/translations'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_arm64.spec
@@ -9,6 +9,7 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
+    ('../../../nitrokeyapp/translations', 'nitrokeyapp/translations'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
+++ b/ci-scripts/macos/pyinstaller/nitrokey-app-onefile_intel64.spec
@@ -9,6 +9,7 @@ python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 datas = [
     (venv_path + '/lib/python' + python_version + '/site-packages/fido2/public_suffix_list.dat', 'fido2'),
     ('../../../nitrokeyapp/ui', 'nitrokeyapp/ui'),
+    ('../../../nitrokeyapp/translations', 'nitrokeyapp/translations'),
     ('../../../LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/ci-scripts/translations.py
+++ b/ci-scripts/translations.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Maintain the Qt Linguist catalogs of the application.
+
+    update    refresh nitrokeyapp/translations/*.ts from the .py and .ui sources
+    release   compile the .ts files into the .qm catalogs that ship with the app
+    check     fail if `update` would change a .ts file (used by the CI)
+
+Everything is driven by the tools that come with PySide6; see
+docs/translations.md.
+"""
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = ROOT / "nitrokeyapp"
+TRANSLATIONS = PACKAGE / "translations"
+
+APP_CATALOG = "nitrokeyapp"
+QT_CATALOG = "qtbase"
+
+# the languages we maintain a catalog for; to add one, put its locale code here
+# and run `make translations-update`
+LANGUAGES = ("de",)
+
+# relative locations keep the references stable across checkouts, -no-obsolete
+# drops removed strings, so a .ts diff shows wording changes and nothing else
+LUPDATE_OPTIONS = ["-locations", "relative", "-no-obsolete"]
+
+LOAD_UI = re.compile(r"""load_ui\(\s*["']([^"']+\.ui)["']""")
+
+
+def tool(name: str) -> str:
+    """Locate one of the PySide6 command line tools."""
+    candidates = [name, str(Path(sys.executable).parent / name)]
+    for candidate in candidates:
+        found = shutil.which(candidate)
+        if found:
+            return found
+    raise SystemExit(f"{name} not found; is PySide6 installed in this environment?")
+
+
+def python_sources() -> list[Path]:
+    sources = (p for p in PACKAGE.rglob("*.py") if "__pycache__" not in p.parts)
+    # sort on the posix form: sorting Path objects orders by the native separator
+    # and lupdate writes the sources in the order it gets them
+    return sorted(sources, key=lambda p: p.as_posix())
+
+
+def ui_sources() -> list[Path]:
+    """The .ui files that are actually loaded; the package also holds unused ones."""
+    names = set()
+    for source in python_sources():
+        names.update(LOAD_UI.findall(source.read_text(encoding="utf-8")))
+
+    files = []
+    for name in sorted(names):
+        path = PACKAGE / "ui" / name
+        if not path.exists():
+            raise SystemExit(f"{path} is loaded but does not exist")
+        files.append(path)
+    return files
+
+
+def catalog(language: str) -> Path:
+    return TRANSLATIONS / f"{APP_CATALOG}_{language}.ts"
+
+
+def relative(paths: list[Path]) -> list[str]:
+    return [p.relative_to(ROOT).as_posix() for p in paths]
+
+
+def update() -> None:
+    TRANSLATIONS.mkdir(parents=True, exist_ok=True)
+    sources = relative(python_sources()) + relative(ui_sources())
+    for language in LANGUAGES:
+        destination = catalog(language)
+        command = [tool("pyside6-lupdate"), *sources, *LUPDATE_OPTIONS, "-ts", str(destination)]
+        subprocess.run(command, check=True, cwd=ROOT)
+
+
+def release() -> None:
+    missing = [language for language in LANGUAGES if not catalog(language).exists()]
+    if missing:
+        raise SystemExit(f"no catalog for {', '.join(missing)}; run `make translations-update`")
+
+    for language in LANGUAGES:
+        source = catalog(language)
+        command = [
+            tool("pyside6-lrelease"),
+            str(source),
+            "-qm",
+            str(source.with_suffix(".qm")),
+        ]
+        subprocess.run(command, check=True, cwd=ROOT)
+
+    copy_qt_catalogs()
+
+
+def copy_qt_catalogs() -> None:
+    """Ship Qt's own translations next to ours, for the bundled builds.
+
+    A PyInstaller bundle does not necessarily contain the translations of the Qt
+    installation, so without this the buttons of the standard dialogs would stay
+    English even in a fully translated application.
+    """
+    from PySide6.QtCore import QLibraryInfo
+
+    qt_translations = Path(QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath))
+    for language in LANGUAGES:
+        source = qt_translations / f"{QT_CATALOG}_{language}.qm"
+        if not source.exists():
+            print(f"warning: Qt ships no {source.name}, skipping", file=sys.stderr)
+            continue
+        shutil.copyfile(source, TRANSLATIONS / source.name)
+
+
+def check() -> None:
+    """Re-run `update` in place, compare, and restore -- the locations lupdate
+    writes are relative to the catalog, so it cannot be run in a scratch directory."""
+    before = {
+        language: catalog(language).read_bytes()
+        for language in LANGUAGES
+        if catalog(language).exists()
+    }
+    try:
+        update()
+        outdated = [
+            language for language in LANGUAGES if catalog(language).read_bytes() != before.get(language)
+        ]
+    finally:
+        for language in LANGUAGES:
+            if language in before:
+                catalog(language).write_bytes(before[language])
+            elif catalog(language).exists():
+                catalog(language).unlink()
+
+    if outdated:
+        raise SystemExit(
+            f"the catalogs for {', '.join(outdated)} are out of date; "
+            "run `make translations-update` and commit the result"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["update", "release", "check"])
+    arguments = parser.parse_args()
+
+    {"update": update, "release": release, "check": check}[arguments.command]()
+
+
+if __name__ == "__main__":
+    main()

--- a/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
+++ b/ci-scripts/windows/pyinstaller/nitrokey-app-onedir.spec
@@ -7,6 +7,7 @@ venv_path = os.popen('poetry env info --path').read().rstrip()
 datas = [
     (venv_path + '\\Lib\\site-packages\\fido2\\public_suffix_list.dat', 'fido2'),
     ('..\\..\\..\\nitrokeyapp\\ui', 'nitrokeyapp\\ui'),
+    ('..\\..\\..\\nitrokeyapp\\translations', 'nitrokeyapp\\translations'),
     ('..\\..\\..\\LICENSE', '.')
 ]
 datas += copy_metadata('fido2')

--- a/nitrokeyapp/__main__.py
+++ b/nitrokeyapp/__main__.py
@@ -9,7 +9,7 @@ from PySide6 import QtWidgets
 from PySide6.QtCore import QEvent, QObject, Qt, QTimer
 from PySide6.QtGui import QFont
 
-from nitrokeyapp import __version__
+from nitrokeyapp import __version__, i18n
 from nitrokeyapp.gui import GUI
 from nitrokeyapp.logger import init_logging, log_environment
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
@@ -870,6 +870,8 @@ class PaletteWatcher(QObject):
 
 def run_gui(argv: list[str]) -> None:
     app = QtWidgets.QApplication(argv)
+    app.setOrganizationName(i18n.ORGANIZATION)
+    app.setApplicationName(i18n.APPLICATION)
     app.setDesktopFileName("com.nitrokey.nitrokey-app2")
     app.setWindowIcon(QtUtilsMixIn.get_qicon("red_nitrokey-app-icon.svg"))
     app.setFont(QFont("Segoe UI", 11))
@@ -906,6 +908,10 @@ def run_gui(argv: list[str]) -> None:
 
     with init_logging() as log_file:
         log_environment()
+
+        # after init_logging so the resolved language is logged, still before
+        # the first widget
+        i18n.install_translators(app)
 
         window = GUI(app, log_file)
         gui.append(window)

--- a/nitrokeyapp/__main__.py
+++ b/nitrokeyapp/__main__.py
@@ -207,6 +207,9 @@ QComboBox {
 }
 QComboBox:focus          { border: 1px solid #6e7781; outline: none; }
 QComboBox::drop-down     { border: none; width: 24px; }
+QComboBox::down-arrow    { image: url(icons:light_mode/down_arrow.svg); width: 12px; height: 12px; }
+QComboBox::down-arrow:on { image: url(icons:light_mode/up_arrow.svg); }
+QComboBox::down-arrow:disabled { image: none; }
 QComboBox QAbstractItemView {
     background-color: #ffffff;
     border: 1px solid #d0d7de;
@@ -615,6 +618,9 @@ QComboBox {
 }
 QComboBox:focus          { border: 1px solid #768390; outline: none; }
 QComboBox::drop-down     { border: none; width: 24px; }
+QComboBox::down-arrow    { image: url(icons:dark_mode/down_arrow_colored.svg); width: 12px; height: 12px; }
+QComboBox::down-arrow:on { image: url(icons:dark_mode/up_arrow_colored.svg); }
+QComboBox::down-arrow:disabled { image: none; }
 QComboBox QAbstractItemView {
     background-color: #161b22;
     border: 1px solid #30363d;

--- a/nitrokeyapp/error_dialog.py
+++ b/nitrokeyapp/error_dialog.py
@@ -18,7 +18,7 @@ class ErrorDialog(QtUtilsMixIn, QDialog):
         # self.ui === self -> this tricks mypy due to monkey-patching self
         self.ui = self.load_ui("error_dialog.ui", self)
 
-        self.button_save_log = QPushButton("Save Log File", self)
+        self.button_save_log = QPushButton(self.tr("Save Log File"), self)
         self.button_save_log.pressed.connect(self.save_log)
 
         self.ui.buttonBox.addButton(self.button_save_log, QDialogButtonBox.ButtonRole.ActionRole)

--- a/nitrokeyapp/error_messages.py
+++ b/nitrokeyapp/error_messages.py
@@ -1,0 +1,194 @@
+"""Our own messages for the errors the device libraries report.
+
+The exceptions of nitrokey-sdk-py and python-fido2 carry English log text that
+is reworded between releases, so the mapping keys on the status codes and error
+enums instead. Anything unmapped falls back to a generic message that carries
+the original text along. See docs/translations.md.
+"""
+
+import logging
+
+from fido2.ctap import CtapError
+from nitrokey.nk3.secrets_app import SecretsAppException, SecretsAppExceptionID
+from nitrokey.trussed.updates import Warning
+from PySide6.QtCore import QCoreApplication
+
+logger = logging.getLogger(__name__)
+
+
+def passwords_unsupported_message() -> str:
+    """Shared wording for the many jobs that need the Passwords application."""
+    return QCoreApplication.translate("errors", "This device does not support Passwords.")
+
+
+def user_message(exc: BaseException) -> str:
+    """A message for `exc` that can be shown to the user, in their language."""
+    if isinstance(exc, SecretsAppException):
+        message = _secrets_app_message(exc)
+    elif isinstance(exc, CtapError):
+        message = _ctap_message(exc)
+    else:
+        message = None
+
+    if message is not None:
+        return message
+
+    detail = str(exc).strip()
+    if not detail:
+        return QCoreApplication.translate("errors", "The operation failed.")
+    return QCoreApplication.translate("errors", "The operation failed: {0}").format(detail)
+
+
+def warning_message(warning: Warning) -> str:
+    """A message for a firmware update warning, keyed by its stable id."""
+    messages = {
+        Warning.IFS_MIGRATION_V2: QCoreApplication.translate(
+            "errors",
+            "There is not enough space on the internal filesystem of the device to perform "
+            "the firmware update. The release notes explain how to free some up: {0}",
+        ).format("https://github.com/Nitrokey/nitrokey-3-firmware/releases/tag/v1.8.2"),
+        Warning.MISSING_STATUS: QCoreApplication.translate(
+            "errors",
+            "The state of the device cannot be determined because its firmware is too old. "
+            "Please update to firmware version v1.3.1 first.",
+        ),
+        Warning.SDK_VERSION: QCoreApplication.translate(
+            "errors",
+            "The Nitrokey SDK this application was built with is too old for the device. "
+            "Please update the Nitrokey App and try again.",
+        ),
+        Warning.UPDATE_FROM_BOOTLOADER: QCoreApplication.translate(
+            "errors",
+            "The state of the device cannot be checked because it is already in bootloader "
+            "mode. Please review the release notes before continuing: {0}",
+        ).format("https://github.com/Nitrokey/nitrokey-3-firmware/releases"),
+    }
+    message = messages.get(warning)
+    if message is None:
+        logger.warning(f"no message for update warning {warning}")
+        return warning.message
+    return message
+
+
+def _secrets_app_message(exc: SecretsAppException) -> str | None:
+    try:
+        code = exc.to_id()
+    except ValueError:
+        logger.warning(f"unknown Passwords status code {exc.code}")
+        return None
+
+    messages = {
+        SecretsAppExceptionID.VerificationFailed: QCoreApplication.translate(
+            "errors", "The PIN is not correct."
+        ),
+        SecretsAppExceptionID.OperationBlocked: QCoreApplication.translate(
+            "errors",
+            "The PIN is blocked because it was entered incorrectly too often. "
+            "A factory reset of Passwords is needed to use it again.",
+        ),
+        SecretsAppExceptionID.SecurityStatusNotSatisfied: QCoreApplication.translate(
+            "errors", "The PIN has to be entered before this operation."
+        ),
+        SecretsAppExceptionID.ConditionsOfUseNotSatisfied: QCoreApplication.translate(
+            "errors", "The operation was not confirmed on the device."
+        ),
+        SecretsAppExceptionID.NotFound: QCoreApplication.translate(
+            "errors", "The credential was not found on the device."
+        ),
+        SecretsAppExceptionID.NotEnoughMemory: QCoreApplication.translate(
+            "errors", "There is not enough space left on the device for another credential."
+        ),
+        SecretsAppExceptionID.IncorrectDataParameter: QCoreApplication.translate(
+            "errors", "The device rejected the data sent."
+        ),
+        SecretsAppExceptionID.WrongLength: QCoreApplication.translate(
+            "errors", "The device rejected the data sent."
+        ),
+        SecretsAppExceptionID.FunctionNotSupported: QCoreApplication.translate(
+            "errors", "This device does not support the requested operation."
+        ),
+        SecretsAppExceptionID.InstructionNotSupportedOrInvalid: QCoreApplication.translate(
+            "errors", "This device does not support the requested operation."
+        ),
+        SecretsAppExceptionID.ClassNotSupported: QCoreApplication.translate(
+            "errors", "This device does not support the requested operation."
+        ),
+    }
+
+    message = messages.get(code)
+    if message is None:
+        logger.info(f"no message for Passwords status {code.name}")
+    return message
+
+
+def _ctap_message(exc: CtapError) -> str | None:
+    error = CtapError.ERR
+    messages = {
+        error.PIN_INVALID: QCoreApplication.translate("errors", "The FIDO2 PIN is not correct."),
+        error.PIN_BLOCKED: QCoreApplication.translate(
+            "errors",
+            "The FIDO2 PIN is blocked because it was entered incorrectly too often. "
+            "A factory reset of FIDO2 is needed to use it again.",
+        ),
+        error.PIN_AUTH_BLOCKED: QCoreApplication.translate(
+            "errors",
+            "The FIDO2 PIN was entered incorrectly too often. Please remove the Nitrokey, "
+            "insert it again and retry.",
+        ),
+        error.PIN_AUTH_INVALID: QCoreApplication.translate(
+            "errors", "The FIDO2 PIN authentication failed."
+        ),
+        error.PIN_NOT_SET: QCoreApplication.translate(
+            "errors", "No FIDO2 PIN is set on this device."
+        ),
+        error.PIN_POLICY_VIOLATION: QCoreApplication.translate(
+            "errors", "The new FIDO2 PIN does not meet the requirements of the device."
+        ),
+        error.PIN_TOKEN_EXPIRED: QCoreApplication.translate(
+            "errors", "The FIDO2 PIN has to be entered again."
+        ),
+        error.PUAT_REQUIRED: QCoreApplication.translate(
+            "errors", "The FIDO2 PIN has to be entered before this operation."
+        ),
+        error.NO_CREDENTIALS: QCoreApplication.translate(
+            "errors", "There are no passkeys stored on this device."
+        ),
+        error.KEY_STORE_FULL: QCoreApplication.translate(
+            "errors", "There is no space left on the device for another passkey."
+        ),
+        error.USER_ACTION_TIMEOUT: QCoreApplication.translate(
+            "errors", "The Nitrokey was not touched in time. Please try again."
+        ),
+        error.ACTION_TIMEOUT: QCoreApplication.translate(
+            "errors", "The Nitrokey was not touched in time. Please try again."
+        ),
+        error.UP_REQUIRED: QCoreApplication.translate(
+            "errors", "The operation has to be confirmed by touching the Nitrokey."
+        ),
+        error.OPERATION_DENIED: QCoreApplication.translate(
+            "errors", "The device refused the operation."
+        ),
+        error.KEEPALIVE_CANCEL: QCoreApplication.translate(
+            "errors", "The operation was cancelled."
+        ),
+        error.NOT_ALLOWED: QCoreApplication.translate(
+            "errors", "The device does not allow this operation."
+        ),
+        error.UV_BLOCKED: QCoreApplication.translate(
+            "errors", "The fingerprint check is blocked. Please use the FIDO2 PIN instead."
+        ),
+        error.UNSUPPORTED_OPTION: QCoreApplication.translate(
+            "errors", "This device does not support the requested operation."
+        ),
+        error.INVALID_OPTION: QCoreApplication.translate(
+            "errors", "This device does not support the requested operation."
+        ),
+        error.INVALID_COMMAND: QCoreApplication.translate(
+            "errors", "This device does not support the requested operation."
+        ),
+    }
+
+    message = messages.get(exc.code)
+    if message is None:
+        logger.info(f"no message for CTAP error {exc.code!r}")
+    return message

--- a/nitrokeyapp/fido2_tab/__init__.py
+++ b/nitrokeyapp/fido2_tab/__init__.py
@@ -89,12 +89,12 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.is_touch_protected.hide()
 
         # repurpose the username/password/comment fields for FIDO2 details (read-only)
-        self.ui.username_label.setText("Display Name:")
+        self.ui.username_label.setText(self.tr("Display Name:"))
         self.ui.username.setReadOnly(True)
-        self.ui.password_label.setText("Username:")
+        self.ui.password_label.setText(self.tr("Username:"))
         self.ui.password.setReadOnly(True)
         self.ui.password.setEchoMode(QLineEdit.EchoMode.Normal)
-        self.ui.comment_label.setText("Credential ID:")
+        self.ui.comment_label.setText(self.tr("Credential ID:"))
         self.ui.comment.setReadOnly(True)
 
         self.algorithm_value = QLabel(self.ui)
@@ -126,7 +126,7 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
 
     @property
     def title(self) -> str:
-        return "Passkeys"
+        return self.tr("Passkeys")
 
     @property
     def widget(self) -> QWidget:
@@ -240,8 +240,8 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
         self.ui.username.setText(credential.user_display_name or "")
         self.ui.password.setText(credential.user_name or "")
         self.ui.comment.setText(credential.credential_id.hex())
-        self.algorithm_value.setText(credential.algorithm_label or "(unknown)")
-        self.cred_protect_value.setText(credential.cred_protect_label or "(not set)")
+        self.algorithm_value.setText(credential.algorithm_label or self.tr("(unknown)"))
+        self.cred_protect_value.setText(credential.cred_protect_label or self.tr("(not set)"))
 
         self.ui.btn_delete.show()
 
@@ -262,8 +262,10 @@ class Fido2Tab(QtUtilsMixIn, QWidget):
 
         confirm = QMessageBox.question(
             self,
-            "Delete Passkey",
-            f"Permanently delete the passkey '{credential.display}' from this device?",
+            self.tr("Delete Passkey"),
+            self.tr("Permanently delete the passkey '{0}' from this device?").format(
+                credential.display
+            ),
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.No,
         )

--- a/nitrokeyapp/fido2_tab/data.py
+++ b/nitrokeyapp/fido2_tab/data.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+from PySide6.QtCore import QCoreApplication
+
 # COSE algorithm identifiers -> human readable names
 # see https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 COSE_ALGORITHMS = {
@@ -16,13 +18,15 @@ COSE_ALGORITHMS = {
     -65535: "RS1",
 }
 
+
 # credProtect policy values -> human readable names
 # see CTAP 2.1, "Credential Protection (credProtect)"
-CRED_PROTECT_POLICIES = {
-    1: "User verification optional",
-    2: "User verification optional (with credential list)",
-    3: "User verification required",
-}
+def cred_protect_policies() -> dict[int, str]:
+    return {
+        1: QCoreApplication.translate("fido2", "User verification optional"),
+        2: QCoreApplication.translate("fido2", "User verification optional (with credential list)"),
+        3: QCoreApplication.translate("fido2", "User verification required"),
+    }
 
 
 @dataclass
@@ -42,7 +46,11 @@ class Fido2Credential:
 
     @property
     def user_label(self) -> str:
-        return self.user_display_name or self.user_name or "(no name)"
+        return (
+            self.user_display_name
+            or self.user_name
+            or QCoreApplication.translate("fido2", "(no name)")
+        )
 
     @property
     def algorithm_label(self) -> str | None:
@@ -54,7 +62,7 @@ class Fido2Credential:
     def cred_protect_label(self) -> str | None:
         if self.cred_protect is None:
             return None
-        return CRED_PROTECT_POLICIES.get(self.cred_protect, str(self.cred_protect))
+        return cred_protect_policies().get(self.cred_protect, str(self.cred_protect))
 
     @property
     def display(self) -> str:
@@ -85,7 +93,11 @@ class Fido2ListState:
         """
         if not self.valid:
             return None
-        parts = [f"{self.existing_count} stored"]
+        # not the %n plural form: lupdate drops a translate() call whose count
+        # argument is an attribute, and the string would never reach the catalog
+        parts = [QCoreApplication.translate("fido2", "{0} stored").format(self.existing_count)]
         if self.remaining_count is not None:
-            parts.append(f"up to {self.remaining_count} free")
-        return "Passkeys: " + ", ".join(parts)
+            parts.append(
+                QCoreApplication.translate("fido2", "up to {0} free").format(self.remaining_count)
+            )
+        return QCoreApplication.translate("fido2", "Passkeys: {0}").format(", ".join(parts))

--- a/nitrokeyapp/fido2_tab/ui.py
+++ b/nitrokeyapp/fido2_tab/ui.py
@@ -19,8 +19,8 @@ class Fido2PinUi(QObject):
     def _query(self, attempts: int) -> None:
         pin, ok = QInputDialog.getText(
             self.app_widget,
-            "Enter FIDO2 PIN",
-            f"Please enter the FIDO2 PIN (remaining retries: {attempts}):",
+            self.tr("Enter FIDO2 PIN"),
+            self.tr("Please enter the FIDO2 PIN (remaining retries: {0}):").format(attempts),
             QLineEdit.EchoMode.Password,
         )
         if ok and pin:

--- a/nitrokeyapp/fido2_tab/worker.py
+++ b/nitrokeyapp/fido2_tab/worker.py
@@ -141,7 +141,7 @@ class ListCredentialsJob(Job):
 
         retries = self._get_pin_retries()
         if retries is None:
-            self.trigger_error("FIDO2 PIN is not set on this device")
+            self.trigger_error(self.tr("No FIDO2 PIN is set on this device"))
             return
 
         self._pin_ui_conn = self.pin_ui.connect_actions(
@@ -169,10 +169,11 @@ class ListCredentialsJob(Job):
             state = self._enumerate(pin)
         except CtapError as e:
             self.pin_cache.clear()
-            self.trigger_error(f"FIDO2 PIN authentication failed: {e}")
+            self.trigger_exception(e)
             return
         except Exception as e:
-            self.trigger_error(f"Failed to list FIDO2 credentials: {e}")
+            logger.error(f"failed to list fido2 credentials: {e}", exc_info=e)
+            self.trigger_error(self.tr("The passkeys could not be read from the device."))
             return
 
         if pin_was_queried:
@@ -221,7 +222,7 @@ class DeleteCredentialJob(Job):
 
         retries = self._get_pin_retries()
         if retries is None:
-            self.trigger_error("FIDO2 PIN is not set on this device")
+            self.trigger_error(self.tr("No FIDO2 PIN is set on this device"))
             return
 
         self._pin_ui_conn = self.pin_ui.connect_actions(
@@ -258,16 +259,17 @@ class DeleteCredentialJob(Job):
                 cred_mgmt.delete_cred(descriptor)
         except CtapError as e:
             self.pin_cache.clear()
-            self.trigger_error(f"FIDO2 delete failed: {e}")
+            self.trigger_exception(e)
             return
         except Exception as e:
-            self.trigger_error(f"Failed to delete FIDO2 credential: {e}")
+            logger.error(f"failed to delete fido2 credential: {e}", exc_info=e)
+            self.trigger_error(self.tr("The passkey could not be deleted."))
             return
 
         if pin_was_queried:
             self.pin_cache.update(self.data, pin)
 
-        self.common_ui.info.info.emit("FIDO2 credential deleted")
+        self.common_ui.info.info.emit(self.tr("Passkey deleted"))
         self.credential_deleted.emit(self.credential)
 
 

--- a/nitrokeyapp/gui.py
+++ b/nitrokeyapp/gui.py
@@ -8,7 +8,7 @@ from types import FrameType, TracebackType
 from nitrokey import _VID_NITROKEY
 from nitrokey.trussed import Model, Transport
 from PySide6 import QtWidgets
-from PySide6.QtCore import QEvent, Qt, QTimer, Signal, Slot
+from PySide6.QtCore import QCoreApplication, QEvent, Qt, QTimer, Signal, Slot
 from PySide6.QtGui import QCursor
 from usbmonitor import USBMonitor
 from usbmonitor.attributes import ID_USB_INTERFACES, ID_VENDOR_ID
@@ -35,15 +35,23 @@ from nitrokeyapp.welcome_tab import WelcomeTab
 logger = logging.getLogger(__name__)
 
 PASSKEYS_TAB_INDEX = 2
-PASSKEYS_ADMIN_REQUIRED_MESSAGE = (
-    "Managing passkeys requires administrator privileges on Windows. "
-    "Please restart the Nitrokey App as administrator to list or delete passkeys."
-)
 
-UPDATE_IN_PROGRESS_MESSAGE = (
-    "A firmware update is in progress. Please wait until it has finished "
-    "before closing the application."
-)
+
+def passkeys_admin_required_message() -> str:
+    return QCoreApplication.translate(
+        "GUI",
+        "Managing passkeys requires administrator privileges on Windows. "
+        "Please restart the Nitrokey App as administrator to list or delete passkeys.",
+    )
+
+
+def update_in_progress_message() -> str:
+    return QCoreApplication.translate(
+        "GUI",
+        "A firmware update is in progress. Please wait until it has finished "
+        "before closing the application.",
+    )
+
 
 SIGNAL_WAKEUP_INTERVAL_MS = 200
 
@@ -166,7 +174,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
         # surface the reason via tooltip on hover.
         self.passkeys_admin_required = get_transport() == Transport.CCID
         if self.passkeys_admin_required:
-            self.tabs.setTabToolTip(PASSKEYS_TAB_INDEX, PASSKEYS_ADMIN_REQUIRED_MESSAGE)
+            self.tabs.setTabToolTip(PASSKEYS_TAB_INDEX, passkeys_admin_required_message())
 
         # set some spacing between Nitrokey buttons
         self.ui.nitrokeyButtonsLayout.setSpacing(8)
@@ -207,7 +215,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
     def handle_sigint(self, sig: int, frame: FrameType | None) -> None:
         if self.is_update_running():
             logger.warning("Ignoring SIGINT: a firmware update is in progress")
-            self.info_box.set_error_status(UPDATE_IN_PROGRESS_MESSAGE)
+            self.info_box.set_error_status(update_in_progress_message())
             return
 
         logger.info("Received SIGINT, closing application")
@@ -455,7 +463,7 @@ class GUI(QtUtilsMixIn, QtWidgets.QMainWindow):
     def closeEvent(self, event: QEvent) -> None:
         if self.is_update_running():
             logger.warning("Ignoring close request: a firmware update is in progress")
-            self.info_box.set_error_status(UPDATE_IN_PROGRESS_MESSAGE)
+            self.info_box.set_error_status(update_in_progress_message())
             event.ignore()
             return
 

--- a/nitrokeyapp/i18n.py
+++ b/nitrokeyapp/i18n.py
@@ -1,0 +1,168 @@
+"""Picks the language and installs the translation catalogs.
+
+Has to run before the first widget is built, see nitrokeyapp.__main__.run_gui.
+The catalogs themselves are documented in docs/translations.md.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from PySide6.QtCore import QCoreApplication, QLibraryInfo, QLocale, QSettings, QTranslator
+
+logger = logging.getLogger(__name__)
+
+ORGANIZATION = "Nitrokey"
+APPLICATION = "nitrokey-app2"
+
+NKAPP_LANG = "NKAPP_LANG"
+LANGUAGE_SETTING = "ui/language"
+
+# the stored value that means "follow the system locale"
+SYSTEM_LANGUAGE = ""
+
+SOURCE_LANGUAGE = "en"
+
+TRANSLATIONS_PATH = Path(__file__).parent / "translations"
+
+APP_CATALOG = "nitrokeyapp"
+QT_CATALOG = "qtbase"
+
+# Qt does not take ownership of an installed translator, so keep a reference
+_installed: list[QTranslator] = []
+
+
+def settings() -> QSettings:
+    """The application settings, stored as an ini file in the user's config directory."""
+    return QSettings(
+        QSettings.Format.IniFormat, QSettings.Scope.UserScope, ORGANIZATION, APPLICATION
+    )
+
+
+def forced_language() -> str | None:
+    """The language enforced via NKAPP_LANG, or None; it beats the setting."""
+    forced = os.environ.get(NKAPP_LANG, "").strip()
+    return forced or None
+
+
+def stored_language() -> str:
+    """The language written by the selector, or :data:`SYSTEM_LANGUAGE`."""
+    stored = settings().value(LANGUAGE_SETTING, SYSTEM_LANGUAGE)
+    return str(stored) if stored else SYSTEM_LANGUAGE
+
+
+def configured_language() -> str:
+    """The language to use, or :data:`SYSTEM_LANGUAGE` to follow the system locale."""
+    return forced_language() or stored_language()
+
+
+def set_configured_language(language: str) -> None:
+    """Store the language to use on the next start."""
+    config = settings()
+    if language:
+        config.setValue(LANGUAGE_SETTING, language)
+    else:
+        config.remove(LANGUAGE_SETTING)
+    config.sync()
+
+
+def available_languages() -> list[str]:
+    """The locale codes we can actually offer, the source language first.
+
+    An untranslated catalog compiles to an empty .qm and would offer a choice
+    that changes nothing, so it is skipped until a translation lands.
+    """
+    languages = set()
+    for catalog in TRANSLATIONS_PATH.glob(f"{APP_CATALOG}_*.qm"):
+        translator = QTranslator()
+        if not translator.load(str(catalog)) or translator.isEmpty():
+            logger.debug(f"skipping {catalog.name}: nothing translated in it")
+            continue
+        languages.add(catalog.stem[len(APP_CATALOG) + 1 :])
+    languages.discard(SOURCE_LANGUAGE)
+    return [SOURCE_LANGUAGE, *sorted(languages)]
+
+
+def language_name(language: str) -> str:
+    """A label for `language`, in that language itself, for the language selector."""
+    if not language:
+        return QCoreApplication.translate("i18n", "System language")
+    if language == SOURCE_LANGUAGE:
+        # Qt resolves a bare "en" to en_US and would call that "American English"
+        return "English"
+
+    name = QLocale(language).nativeLanguageName()
+    if not name:
+        return language
+    return name[:1].upper() + name[1:]
+
+
+def _load(locale: QLocale, catalog: str, directories: list[Path]) -> QTranslator | None:
+    for directory in directories:
+        translator = QTranslator()
+        # QTranslator walks the fallback chain itself, so de_DE finds a de catalog
+        if translator.load(locale, catalog, "_", str(directory)):
+            logger.debug(f"loaded {catalog} catalog from {directory}")
+            return translator
+    logger.debug(f"no {catalog} catalog for {locale.name()}")
+    return None
+
+
+def resolved_language() -> str:
+    """The language to load catalogs for.
+
+    Without a usable setting this takes the first language the system says the
+    user prefers that we can serve, counting the source language as servable:
+    someone who prefers English over German must not get a half German
+    application just because we ship a German catalog and no English one.
+    """
+    forced = forced_language()
+    if forced:
+        return forced
+
+    available = set(available_languages())
+
+    stored = stored_language()
+    if stored in available:
+        return stored
+    if stored:
+        logger.warning(f"no catalog for the selected language {stored!r}")
+
+    for tag in QLocale.system().uiLanguages():
+        name = QLocale(tag).name()
+        language = name.split("_")[0]
+        if language == SOURCE_LANGUAGE:
+            return SOURCE_LANGUAGE
+        for candidate in (name, language):
+            if candidate in available:
+                return candidate
+    return SOURCE_LANGUAGE
+
+
+def install_translators(app: QCoreApplication) -> None:
+    """Install the application and Qt catalogs matching the configured language."""
+    language = resolved_language()
+    locale = QLocale(language)
+    if configured_language():
+        # an explicit choice also switches number and date formatting
+        QLocale.setDefault(locale)
+
+    setting = configured_language() or "system"
+    logger.info(f"using locale {locale.name()} (language setting: {setting})")
+
+    if language == SOURCE_LANGUAGE:
+        logger.debug("the source language needs no catalogs")
+        return
+
+    # Qt's own strings (dialog buttons, context menus); prefer the installed Qt,
+    # fall back to the copies we ship for the bundled builds
+    qt_directories = [
+        Path(QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath)),
+        TRANSLATIONS_PATH,
+    ]
+    for catalog, directories in ((QT_CATALOG, qt_directories), (APP_CATALOG, [TRANSLATIONS_PATH])):
+        translator = _load(locale, catalog, directories)
+        if translator is None:
+            continue
+        app.installTranslator(translator)
+        _installed.append(translator)

--- a/nitrokeyapp/information_box.py
+++ b/nitrokeyapp/information_box.py
@@ -34,6 +34,8 @@ class InfoBox(QObject):
         self.status.hide()
         self.device = device
 
+        self.touch_status = False
+
         self.icon = icon
         self.icon.setFixedSize(QtCore.QSize(16, 16))
         self.icon.hide()
@@ -58,6 +60,7 @@ class InfoBox(QObject):
 
     @Slot(str, int, str)
     def set_status(self, text: str, timeout: int = 7000, icon: str | None = None) -> None:
+        self.touch_status = False
         self.status.setText(text)
         self.status.setStyleSheet("color: #1a1a1a;")
         self.status.show()
@@ -80,18 +83,19 @@ class InfoBox(QObject):
 
     @Slot()
     def hide_status(self) -> None:
+        self.touch_status = False
         self.status.setText("")
         self.status.setStyleSheet("")
         self.icon.hide()
 
     @Slot()
     def set_touch_status(self) -> None:
-        self.set_status("Press your Nitrokey to confirm...", 15000, "touch.svg")
+        self.set_status(self.tr("Press your Nitrokey to confirm..."), 15000, "touch.svg")
+        self.touch_status = True
 
     @Slot()
     def hide_touch(self) -> None:
-        # TODO: no good
-        if "Press" in self.status.text():
+        if self.touch_status:
             self.hide_status()
 
     def set_device(self, text: str) -> None:
@@ -114,8 +118,8 @@ class InfoBox(QObject):
     def set_pin_icon(self, pin_cached: bool = True) -> None:
         if pin_cached:
             self.pin_icon.setIcon(QtUtilsMixIn.get_qicon("dialpad.svg"))
-            self.pin_icon.setToolTip("Passwords PIN is cached - click to clear")
+            self.pin_icon.setToolTip(self.tr("Passwords PIN is cached - click to clear"))
         else:
             self.pin_icon.setIcon(QtUtilsMixIn.get_qicon("dialpad_off.svg"))
-            self.pin_icon.setToolTip("Passwords PIN locked")
+            self.pin_icon.setToolTip(self.tr("Passwords PIN locked"))
         self.pin_icon.show()

--- a/nitrokeyapp/logger.py
+++ b/nitrokeyapp/logger.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from importlib.metadata import version as package_version
 from pathlib import Path
 
+from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QFileDialog, QWidget
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,8 @@ def log_environment() -> None:
 
 
 def save_log(log_file: str, parent: QWidget) -> None:
-    path, _ = QFileDialog.getSaveFileName(parent, "Save Log File")
+    title = QCoreApplication.translate("logger", "Save Log File")
+    path, _ = QFileDialog.getSaveFileName(parent, title)
     if path:
         root_logger = logging.getLogger()
         for handler in root_logger.handlers:

--- a/nitrokeyapp/nk3_button.py
+++ b/nitrokeyapp/nk3_button.py
@@ -103,7 +103,7 @@ class Nk3Button(QtWidgets.QToolButton):
 
     def start_touch(self) -> None:
         self.animation.start()
-        self.setToolTip("touch your Nitrokey 3")
+        self.setToolTip(self.tr("Touch your Nitrokey 3"))
 
     def stop_touch(self) -> None:
         self.animation.stop()

--- a/nitrokeyapp/overview_tab/__init__.py
+++ b/nitrokeyapp/overview_tab/__init__.py
@@ -57,7 +57,7 @@ class OverviewTab(QtUtilsMixIn, QWidget):
 
     @property
     def title(self) -> str:
-        return "Overview"
+        return self.tr("Overview")
 
     @property
     def widget(self) -> QWidget:
@@ -80,12 +80,16 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         # catch too old firmware
         if data.is_too_old:
             self.set_device_data(
-                str(data.path), "n/a", "n/a", "Update Your Nitrokey 3 for full functionality", "n/a"
+                str(data.path),
+                "n/a",
+                "n/a",
+                self.tr("Update your Nitrokey 3 for full functionality"),
+                "n/a",
             )
             self.ui.status_label.hide()
             self.ui.nk3_status.hide()
             self.ui.more_info.hide()
-            self.ui.nk3_label.setText("Nitrokey 3 (old firmware)")
+            self.ui.nk3_label.setText(self.tr("Nitrokey 3 (old firmware)"))
             self.status_error(InitStatus(0))
             return
 
@@ -94,7 +98,7 @@ class OverviewTab(QtUtilsMixIn, QWidget):
             self.ui.status_label.hide()
             self.ui.nk3_status.hide()
             self.ui.more_info.hide()
-            self.ui.nk3_label.setText(f"{data.model} Bootloader")
+            self.ui.nk3_label.setText(self.tr("{0} Bootloader").format(data.model))
             self.status_error(InitStatus(0))
 
         else:
@@ -136,23 +140,23 @@ class OverviewTab(QtUtilsMixIn, QWidget):
         tooltip = ""
         btn_really_enabled = enabled and not self.using_ccid
         if enabled and self.using_ccid:
-            self.common_ui.info.info.emit(
-                "Please restart the application as an administrator to be able to update"
+            tooltip = self.tr(
+                "Please restart the application as an administrator to be able to update."
             )
-            tooltip = "Please restart the application as an administrator to be able to update"
+            self.common_ui.info.info.emit(tooltip)
 
         if not enabled:
-            self.common_ui.info.info.emit(
+            tooltip = self.tr(
                 "Please remove all Nitrokey devices except the one you want to update."
             )
-            tooltip = "Please remove all Nitrokey devices except the one you want to update."
+            self.common_ui.info.info.emit(tooltip)
 
         for btn in [self.ui.btn_update, self.ui.btn_update_with_file]:
             btn.setEnabled(btn_really_enabled)
             btn.setToolTip(tooltip)
 
     def update_btns_during_update(self, enabled: bool) -> None:
-        tooltip = "" if enabled else "Update is already running. Please wait."
+        tooltip = "" if enabled else self.tr("Update is already running. Please wait.")
         self.busy_state_changed.emit(not enabled)
         for btn in [self.ui.btn_update, self.ui.btn_update_with_file]:
             btn.setEnabled(enabled)
@@ -170,18 +174,24 @@ class OverviewTab(QtUtilsMixIn, QWidget):
     def device_updated(self, result: UpdateResult) -> None:
         self.update_btns_during_update(True)
 
-        msg = ""
+        if result.status == UpdateStatus.SUCCESS:
+            text = self.tr("{0} successfully updated").format(result.model)
+        elif result.status == UpdateStatus.ERROR:
+            text = self.tr("{0} update failed").format(result.model)
+        elif result.status == UpdateStatus.ABORTED:
+            text = self.tr("{0} update aborted").format(result.model)
+        else:
+            logger.error(f"unexpected update result: {result.status}")
+            text = self.tr("{0} update failed").format(result.model)
+
+        # the message is already translated, see nitrokeyapp.update
         if result.message is not None:
-            msg = ": " + result.message
+            text = self.tr("{0}: {1}").format(text, result.message)
 
         if result.status == UpdateStatus.SUCCESS:
-            self.common_ui.info.info.emit(f"{result.model} successfully updated{msg}")
-        elif result.status == UpdateStatus.ERROR:
-            self.common_ui.info.error.emit(f"{result.model} update failed{msg}")
-        elif result.status == UpdateStatus.ABORTED:
-            self.common_ui.info.error.emit(f"{result.model} update aborted{msg}")
+            self.common_ui.info.info.emit(text)
         else:
-            self.common_ui.info.error.emit(f"Unexpected update result: {result.status}{msg}")
+            self.common_ui.info.error.emit(text)
 
         self.common_ui.gui.refresh_devices.emit()
 

--- a/nitrokeyapp/secrets_tab/__init__.py
+++ b/nitrokeyapp/secrets_tab/__init__.py
@@ -41,6 +41,11 @@ from .worker import SecretsWorker
 
 logger = logging.getLogger(__name__)
 
+PASSWORD_ONLY = ""
+
+# the entries of the algorithm combo box, by position; the labels are translated
+ALGORITHM_KINDS = [PASSWORD_ONLY, "TOTP", "HOTP", "HMAC"]
+
 
 class PasswordGenRow(QWidget):
     """Password-generator filters that adapt to the available width.
@@ -209,7 +214,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         self.action_password_generate = self.ui.password.addAction(icon_generate, loc)
         self.action_password_generate.triggered.connect(self.act_toggle_password_gen)
-        self.action_password_generate.setToolTip("Generate random password")
+        self.action_password_generate.setToolTip(self.tr("Generate random password"))
 
         self._pw_gen_widget = self._create_password_gen_widget()
         self._pw_gen_widget.hide()
@@ -290,9 +295,25 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         self.reset()
 
+    def algorithm_kind(self) -> str:
+        """The credential kind selected in the algorithm combo box."""
+        index = self.ui.select_algorithm.currentIndex()
+        if 0 <= index < len(ALGORITHM_KINDS):
+            return ALGORITHM_KINDS[index]
+        return PASSWORD_ONLY
+
+    def select_algorithm_kind(self, kind: str) -> None:
+        if kind not in ALGORITHM_KINDS:
+            return
+        index = ALGORITHM_KINDS.index(kind)
+        # while editing, HMAC is dropped again (setMaxCount(3)) and selecting an
+        # index the combo box no longer has would clear it
+        if index < self.ui.select_algorithm.count():
+            self.ui.select_algorithm.setCurrentIndex(index)
+
     @property
     def title(self) -> str:
-        return "Passwords"
+        return self.tr("Passwords")
 
     @property
     def widget(self) -> QWidget:
@@ -393,7 +414,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
     @Slot(OtpData)
     def otp_generated(self, data: OtpData) -> None:
         self.ui.otp.setText(data.otp)
-        self.common_ui.info.info.emit("Secret is generated")
+        self.common_ui.info.info.emit(self.tr("Secret is generated"))
 
         if data.validity:
             start, end = data.validity
@@ -411,12 +432,15 @@ class SecretsTab(QtUtilsMixIn, QWidget):
     def backup_credentials(self) -> None:
         if not self.data:
             return
-        self._open_backup_restore(BackupRestoreAction.BACKUP, "Backup passwords")
+        self._open_backup_restore(BackupRestoreAction.BACKUP, self.tr("Backup passwords"))
 
     @Slot(str)
     def save_credential_backup(self, credential_list_formatted: str) -> None:
         path, _ = QFileDialog.getSaveFileName(
-            self, "Save Credential Backup", "credential_backup.json", "JSON Files (*.json)"
+            self,
+            self.tr("Save Credential Backup"),
+            "credential_backup.json",
+            self.tr("JSON Files (*.json)"),
         )
         if path:
             with open(path, "w") as f:
@@ -427,13 +451,15 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         if not self.data:
             return
         path, _ = QFileDialog.getOpenFileName(
-            self, "Open Credential Backup", "", "JSON Files (*.json)"
+            self, self.tr("Open Credential Backup"), "", self.tr("JSON Files (*.json)")
         )
         if not path:
             return
         with open(path, "r") as f:
             self.backup_content = f.read()
-        self._open_backup_restore(BackupRestoreAction.RESTORE, f"Restore passwords from {path}")
+        self._open_backup_restore(
+            BackupRestoreAction.RESTORE, self.tr("Restore passwords from {0}").format(path)
+        )
 
     @Slot()
     def on_credential_restored(self) -> None:
@@ -556,7 +582,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             self.ui.otp.show()
             self.ui.otp.setReadOnly(True)
             self.ui.algorithm.setText(str(credential.otp or credential.other) + ":")
-            self.ui.otp.setPlaceholderText("<hidden>")
+            self.ui.otp.setPlaceholderText(self.tr("<hidden>"))
 
             if credential.otp:
                 self.action_otp_copy.setVisible(True)
@@ -644,7 +670,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         if credential.otp or credential.other:
             self.ui.otp.setReadOnly(True)
 
-            self.ui.select_algorithm.setCurrentText(str(credential.otp or credential.other))
+            self.select_algorithm_kind(str(credential.otp or credential.other))
             self.ui.select_algorithm.setEnabled(False)
             self.action_hmac_gen.setVisible(False)
 
@@ -652,20 +678,20 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             self.action_otp_gen.setVisible(False)
             if credential.otp:
                 self.action_otp_edit.setVisible(True)
-                self.ui.otp.setPlaceholderText("<hidden - click to edit>")
+                self.ui.otp.setPlaceholderText(self.tr("<hidden - click to edit>"))
             else:
                 self.ui.algorithm_show.show()
                 self.ui.algorithm_edit.hide()
                 self.ui.algorithm.setText(str(credential.otp or credential.other) + ":")
                 self.action_otp_edit.setVisible(False)
-                self.ui.otp.setPlaceholderText("<cannot edit>")
+                self.ui.otp.setPlaceholderText(self.tr("<cannot edit>"))
 
         # no otp there, just offer it as in add
         else:
             self.ui.otp.clear()
             self.ui.otp.setReadOnly(False)
-            self.ui.otp.setPlaceholderText("<empty>")
-            self.ui.select_algorithm.setCurrentText("Password only")
+            self.ui.otp.setPlaceholderText(self.tr("<empty>"))
+            self.select_algorithm_kind(PASSWORD_ONLY)
             self.ui.select_algorithm.setEnabled(True)
 
         self.check_credential()
@@ -681,7 +707,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         self.ui.otp.setReadOnly(False)
         self.ui.select_algorithm.setEnabled(True)
-        self.ui.otp.setPlaceholderText("<empty>")
+        self.ui.otp.setPlaceholderText(self.tr("<empty>"))
         self.ui.otp.clear()
 
         self.check_credential()
@@ -722,7 +748,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.name.clear()
 
         self.ui.otp.clear()
-        self.ui.otp.setPlaceholderText("<empty>")
+        self.ui.otp.setPlaceholderText(self.tr("<empty>"))
         self.ui.username.clear()
         self.ui.password.clear()
         self.ui.comment.clear()
@@ -751,7 +777,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.ui.algorithm_show.hide()
 
         self.ui.select_algorithm.show()
-        self.ui.select_algorithm.setCurrentText("Password only")
+        self.select_algorithm_kind(PASSWORD_ONLY)
         self.ui.select_algorithm.setEnabled(True)
         self.action_hmac_gen.setVisible(False)
 
@@ -766,7 +792,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
     def check_credential(self) -> None:
         self.common_ui.info.info.emit("")
 
-        tool_Tip = "Credential cannot be saved:"
+        tool_Tip = self.tr("Credential cannot be saved:")
         can_save = True
         check_secret = self.ui.otp.text().replace(" ", "").replace("-", "")
 
@@ -775,7 +801,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         password_len = len(str.encode(self.ui.password.text()))
         comment_len = len(str.encode(self.ui.comment.text()))
 
-        algo = self.ui.select_algorithm.currentText()
+        algo = self.algorithm_kind()
 
         if len(self.ui.uri.text()) > 9:
             can_save = True
@@ -783,81 +809,85 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             if len(self.ui.name.text()) < 3:
                 can_save = False
             if len(self.ui.name.text()) == 0:
-                self.common_ui.info.info.emit("Enter a Credential Name")
-                tool_Tip = tool_Tip + "\n- Enter a Credential Name"
+                self.common_ui.info.info.emit(self.tr("Enter a Credential Name"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Enter a Credential Name")
             if len(self.ui.name.text()) >= 1 and len(self.ui.name.text()) < 3:
-                self.common_ui.info.info.emit("Credential Name is too short")
-                tool_Tip = tool_Tip + "\n- Credential Name is too short"
+                self.common_ui.info.info.emit(self.tr("Credential Name is too short"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Credential Name is too short")
             if name_len >= 128:
                 can_save = False
-                self.common_ui.info.info.emit("Credential Name is too long")
-                tool_Tip = tool_Tip + "\n- Credential Name is too long"
+                self.common_ui.info.info.emit(self.tr("Credential Name is too long"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Credential Name is too long")
 
             if username_len >= 128:
                 can_save = False
-                self.common_ui.info.info.emit("Username is too long")
-                tool_Tip = tool_Tip + "\n- Username is too long"
+                self.common_ui.info.info.emit(self.tr("Username is too long"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Username is too long")
 
             if password_len >= 128:
                 can_save = False
-                self.common_ui.info.info.emit("Password is too long")
-                tool_Tip = tool_Tip + "\n- Password is too long"
+                self.common_ui.info.info.emit(self.tr("Password is too long"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Password is too long")
 
             if comment_len >= 128:
                 can_save = False
-                self.common_ui.info.info.emit("Comment is too long")
-                tool_Tip = tool_Tip + "\n- Comment is too long"
+                self.common_ui.info.info.emit(self.tr("Comment is too long"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Comment is too long")
 
         if self.ui.select_algorithm.isEnabled():
-            if algo == "Password only":
+            if algo == PASSWORD_ONLY:
                 self.ui.otp.setReadOnly(True)
-                self.ui.otp.setPlaceholderText("OTP not configured")
+                self.ui.otp.setPlaceholderText(self.tr("OTP not configured"))
             else:
                 self.ui.otp.setReadOnly(False)
-                self.ui.otp.setPlaceholderText("<empty>")
+                self.ui.otp.setPlaceholderText(self.tr("<empty>"))
 
                 if algo == "HMAC":
                     self.show_hmac_view()
                     if len(check_secret) != 32:
                         can_save = False
-                        self.common_ui.info.info.emit("The HMAC-Secret is not 32 chars long")
-                        tool_Tip = tool_Tip + "\n- The HMAC-Secret is not 32 chars long"
+                        self.common_ui.info.info.emit(
+                            self.tr("The HMAC-Secret is not 32 chars long")
+                        )
+                        tool_Tip = (
+                            tool_Tip + "\n- " + self.tr("The HMAC-Secret is not 32 chars long")
+                        )
                 else:
                     self.hide_hmac_view()
 
-                if algo != "None" and len(check_secret) != len(check_secret.encode()):
+                if len(check_secret) != len(check_secret.encode()):
                     can_save = False
-                    self.common_ui.info.info.emit("Invalid character in Secret")
-                    tool_Tip = tool_Tip + "\n- Invalid character in Secret"
+                    self.common_ui.info.info.emit(self.tr("Invalid character in Secret"))
+                    tool_Tip = tool_Tip + "\n- " + self.tr("Invalid character in Secret")
                 elif not is_base32(check_secret) and len(check_secret) > 1:
                     can_save = False
-                    self.common_ui.info.info.emit("Secret is not in Base32")
-                    tool_Tip = tool_Tip + "\n- Secret is not in Base32"
+                    self.common_ui.info.info.emit(self.tr("Secret is not in Base32"))
+                    tool_Tip = tool_Tip + "\n- " + self.tr("Secret is not in Base32")
 
-            if algo != "Password only" and len(check_secret) != len(check_secret.encode()):
+            if algo != PASSWORD_ONLY and len(check_secret) != len(check_secret.encode()):
                 can_save = False
-                self.common_ui.info.info.emit("Invalid character in Secret")
-                tool_Tip = tool_Tip + "\n- Invalid character in Secret"
+                self.common_ui.info.info.emit(self.tr("Invalid character in Secret"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Invalid character in Secret")
             elif not is_base32(check_secret) and len(check_secret) > 1:
                 can_save = False
-                self.common_ui.info.info.emit("Secret is not valid Base32")
-                tool_Tip = tool_Tip + "\n- Secret is not valid Base32"
+                self.common_ui.info.info.emit(self.tr("Secret is not valid Base32"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Secret is not valid Base32")
 
-            if algo != "Password only" and len(check_secret) < 1:
+            if algo != PASSWORD_ONLY and len(check_secret) < 1:
                 can_save = False
-                self.common_ui.info.info.emit("Enter a Secret")
-                tool_Tip = tool_Tip + "\n- Enter a Secret"
+                self.common_ui.info.info.emit(self.tr("Enter a Secret"))
+                tool_Tip = tool_Tip + "\n- " + self.tr("Enter a Secret")
 
         self.ui.btn_save.setEnabled(can_save)
         if can_save:
-            tool_Tip = "Credential Save"
+            tool_Tip = self.tr("Save credential")
 
         self.ui.btn_save.setToolTip(tool_Tip)
 
     def act_copy_line_edit(self, obj: QLineEdit) -> None:
         copied_text = obj.text()
         self.clipboard.setText(copied_text)
-        self.common_ui.info.info.emit("contents copied to clipboard")
+        self.common_ui.info.info.emit(self.tr("Contents copied to clipboard"))
         self.line2copy_action[obj].setIcon(self.get_qicon("done.svg"))
         QTimer.singleShot(
             5000, lambda: self.line2copy_action[obj].setIcon(self.get_qicon("content_copy.svg"))
@@ -924,7 +954,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             alphabet += "!#$%&()*+,-.:;<=>?@[]^_{|}~"
         if not alphabet:
             self.common_ui.info.info.emit(
-                "Select at least one character group to generate a password"
+                self.tr("Select at least one character group to generate a password")
             )
             return
         password = "".join(choice(alphabet) for _ in range(self._pw_gen_length.value()))
@@ -946,11 +976,11 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             widget.setMinimumWidth(width)
 
     def _create_password_gen_widget(self) -> QWidget:
-        self._pw_gen_letters = QCheckBox("Letters")
+        self._pw_gen_letters = QCheckBox(self.tr("Letters"))
         self._pw_gen_letters.setChecked(True)
-        self._pw_gen_digits = QCheckBox("Digits")
+        self._pw_gen_digits = QCheckBox(self.tr("Digits"))
         self._pw_gen_digits.setChecked(True)
-        self._pw_gen_punctuation = QCheckBox("Symbols")
+        self._pw_gen_punctuation = QCheckBox(self.tr("Symbols"))
         self._pw_gen_punctuation.setChecked(True)
 
         self._pw_gen_length = QSpinBox()
@@ -968,7 +998,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         length_group.setStyleSheet("QWidget#pw_gen_length_group { background: transparent; }")
         length_layout = QHBoxLayout(length_group)
         length_layout.setContentsMargins(0, 0, 0, 0)
-        length_layout.addWidget(QLabel("Length:"))
+        length_layout.addWidget(QLabel(self.tr("Length:")))
         length_layout.addWidget(self._pw_gen_length)
 
         return PasswordGenRow(
@@ -1045,7 +1075,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         self.otp_timer.stop()
         self.ui.otp_timeout_progress.hide()
         self.ui.otp.clear()
-        self.ui.otp.setPlaceholderText("<hidden>")
+        self.ui.otp.setPlaceholderText(self.tr("<hidden>"))
 
     @Slot()
     def update_otp_timeout(self) -> None:
@@ -1090,10 +1120,10 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
         msg_box = QMessageBox(self)
         msg_box.setIcon(QMessageBox.Icon.Warning)
-        msg_box.setWindowTitle("Delete Credential")
-        msg_box.setText(f"Delete '{credential.name}' from the device?")
-        msg_box.setInformativeText("This action cannot be undone.")
-        delete_btn = msg_box.addButton("Delete", QMessageBox.ButtonRole.DestructiveRole)
+        msg_box.setWindowTitle(self.tr("Delete Credential"))
+        msg_box.setText(self.tr("Delete '{0}' from the device?").format(credential.name))
+        msg_box.setInformativeText(self.tr("This action cannot be undone."))
+        delete_btn = msg_box.addButton(self.tr("Delete"), QMessageBox.ButtonRole.DestructiveRole)
         msg_box.addButton(QMessageBox.StandardButton.Cancel)
         msg_box.setDefaultButton(QMessageBox.StandardButton.Cancel)
         msg_box.exec()
@@ -1109,7 +1139,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
         comment = self.ui.comment.text()
         user_presence = self.ui.is_touch_protected.isChecked()
         pin_protected = self.ui.is_pin_protected.isChecked()
-        kind_str = self.ui.select_algorithm.currentText()
+        kind_str = self.algorithm_kind()
         uri = self.ui.uri.text()
 
         if len(name) < 3:
@@ -1139,7 +1169,7 @@ class SecretsTab(QtUtilsMixIn, QWidget):
             touch_required=user_presence,
             uri=uri,
             new_secret=self.ui.select_algorithm.isEnabled()
-            and self.ui.select_algorithm.currentText() != "Password only",
+            and self.algorithm_kind() != PASSWORD_ONLY,
         )
 
         if self.active_credential is None:
@@ -1166,34 +1196,43 @@ class SecretsTab(QtUtilsMixIn, QWidget):
 
     def _open_backup_restore(self, action: BackupRestoreAction, title: str) -> None:
         ui = open_backup_restore_ui(action, title, self.icon_copy, self)
-        ui.update_status("Idle")
+        ui.update_status(self.tr("Idle"))
 
         self._worker.passphrase_ready.connect(ui.update_passphrase)
         self._worker.backup_progress.connect(ui.update_fields)
         self._worker.restore_progress.connect(ui.update_fields)
-        self._worker.credential_bkp.connect(lambda _: ui.update_status("Backup complete"))
-        self._worker.credential_restore.connect(lambda: ui.update_status("Restore complete"))
+        self._worker.credential_bkp.connect(lambda _: ui.update_status(self.tr("Backup complete")))
+        self._worker.credential_restore.connect(
+            lambda: ui.update_status(self.tr("Restore complete"))
+        )
+
+        working = self.tr("Working... Press your Nitrokey if it blinks.")
 
         def on_begin(cleartext: bool, passphrase: str, action_name: BackupRestoreAction) -> None:
             if action_name == BackupRestoreAction.BACKUP:
-                ui.update_status("Working... Press your Nitrokey if it blinks.")
+                ui.update_status(working)
                 self.trigger_backup_credential.emit(self.data, True, cleartext)
             else:
                 try:
                     tempdata = json.loads(self.backup_content)
                     process_restore = True
                     if "EncryptedCXF" in tempdata and not passphrase:
-                        ui.update_status("The backup is encrypted. Please enter the passphrase.")
+                        ui.update_status(
+                            self.tr("The backup is encrypted. Please enter the passphrase.")
+                        )
                         process_restore = False
                     elif "EncryptedCXF" not in tempdata and passphrase:
-                        ui.update_status("The backup is not encrypted. Ignoring passphrase.")
+                        ui.update_status(
+                            self.tr("The backup is not encrypted, the passphrase is ignored.")
+                        )
                         passphrase = ""
                     if process_restore:
-                        ui.update_status("Working... Press your Nitrokey if it blinks.")
+                        ui.update_status(working)
                         self.trigger_restore_credential.emit(
                             self.data, self.backup_content, passphrase
                         )
                 except json.JSONDecodeError as e:
-                    ui.update_status(f"Invalid backup file {e}")
+                    logger.error(f"invalid backup file: {e}")
+                    ui.update_status(self.tr("The backup file could not be read."))
 
         ui.begin(on_begin)

--- a/nitrokeyapp/secrets_tab/backup_restore_ui.py
+++ b/nitrokeyapp/secrets_tab/backup_restore_ui.py
@@ -29,30 +29,35 @@ class BackupRestoreUi(QDialog):
         super().__init__(parent)
 
         self.name = name
-        self.setWindowTitle(name.capitalize())
+        self.setWindowTitle(
+            self.tr("Backup") if name == BackupRestoreAction.BACKUP else self.tr("Restore")
+        )
 
-        self.action_edit = QLabel(f"Action: {title}")
+        self.action_edit = QLabel(self.tr("Action: {0}").format(title))
 
         action_layout = QHBoxLayout()
         action_layout.addWidget(self.action_edit)
 
-        self.cleartext_checkbox = QCheckBox("Cleartext")
+        self.cleartext_checkbox = QCheckBox(self.tr("Cleartext"))
         self.cleartext_checkbox.setToolTip(
-            "This option disables encryption of the generated backup and is discouraged. Only use for interoperability with other password managers."
+            self.tr(
+                "This option disables encryption of the generated backup and is discouraged. "
+                "Only use it for interoperability with other password managers."
+            )
         )
         self.cleartext_checkbox.setVisible(name == BackupRestoreAction.BACKUP)
 
         self.passphrase_edit = QLineEdit()
         self.passphrase_edit.setToolTip(
-            "Passphrase is automatically created during an encrypted backup."
+            self.tr("The passphrase is created automatically during an encrypted backup.")
         )
         self.passphrase_edit.setReadOnly(name == BackupRestoreAction.BACKUP)
 
         self.copy_passphrase_button = QToolButton()
         self.copy_passphrase_button.setIcon(icon)
-        self.copy_passphrase_button.setToolTip("Copy passphrase")
+        self.copy_passphrase_button.setToolTip(self.tr("Copy passphrase"))
 
-        self.begin_button = QPushButton("Begin")
+        self.begin_button = QPushButton(self.tr("Begin"))
 
         passphrase_layout = QHBoxLayout()
         passphrase_layout.setContentsMargins(0, 0, 0, 0)
@@ -63,7 +68,7 @@ class BackupRestoreUi(QDialog):
         middle_layout = QHBoxLayout()
         middle_layout.addWidget(self.cleartext_checkbox)
         middle_layout.addStretch(1)
-        middle_layout.addWidget(QLabel("Passphrase"))
+        middle_layout.addWidget(QLabel(self.tr("Passphrase")))
         middle_layout.addLayout(passphrase_layout, 1)
         middle_layout.addWidget(self.begin_button)
 
@@ -74,22 +79,32 @@ class BackupRestoreUi(QDialog):
         self.skipped_list = QListWidget()
 
         self.failed_name = (
-            "Not passwords" if name == BackupRestoreAction.BACKUP else "Already exists"
-        )
-
-        self.successful_label = QLabel("Successful (0)")
-        self.successful_label.setToolTip("Operation on these credentials completed successfully")
-
-        self.failed_label = QLabel(f"{self.failed_name} (0)")
-        self.failed_label.setToolTip(
-            "Credentials without a password (for example OTP only) are skipped during the backup as they cannot be extracted from the device."
+            self.tr("Not passwords")
             if name == BackupRestoreAction.BACKUP
-            else "Credentials not imported because a credential with same label already exists on the device"
+            else self.tr("Already exists")
         )
 
-        self.skipped_label = QLabel("Skipped (0)")
+        self.successful_label = QLabel(self.count_label(self.tr("Successful"), 0))
+        self.successful_label.setToolTip(
+            self.tr("The operation on these credentials completed successfully")
+        )
+
+        self.failed_label = QLabel(self.count_label(self.failed_name, 0))
+        self.failed_label.setToolTip(
+            self.tr(
+                "Credentials without a password (for example OTP only) are skipped during "
+                "the backup, as they cannot be extracted from the device."
+            )
+            if name == BackupRestoreAction.BACKUP
+            else self.tr(
+                "Credentials that were not imported because a credential with the same "
+                "label already exists on the device"
+            )
+        )
+
+        self.skipped_label = QLabel(self.count_label(self.tr("Skipped"), 0))
         self.skipped_label.setToolTip(
-            "Credentials are skipped if they are PIN protected but PIN is not supplied."
+            self.tr("Credentials are skipped if they are PIN protected but no PIN was supplied.")
         )
 
         lists_layout = QHBoxLayout()
@@ -107,7 +122,7 @@ class BackupRestoreUi(QDialog):
         # self.status_edit.setReadOnly(True)
 
         status_layout = QHBoxLayout()
-        status_layout.addWidget(QLabel("Status"))
+        status_layout.addWidget(QLabel(self.tr("Status")))
         status_layout.addWidget(self.status_edit)
 
         layout = QVBoxLayout()
@@ -120,12 +135,15 @@ class BackupRestoreUi(QDialog):
 
         self.resize(900, 520)
 
+    def count_label(self, name: str, count: int) -> str:
+        return self.tr("{0} ({1})").format(name, count)
+
     def copy_passphrase(self) -> None:
         if self.passphrase_edit.text() != "":
             QGuiApplication.clipboard().setText(self.passphrase_edit.text())
-            self.update_status("Passphrase copied!")
+            self.update_status(self.tr("Passphrase copied"))
         else:
-            self.update_status("Nothing to copy!")
+            self.update_status(self.tr("Nothing to copy"))
 
     def update_fields(
         self, success_list: List[bytes], failed_list: List[bytes], skipped_list: List[bytes]
@@ -143,9 +161,9 @@ class BackupRestoreUi(QDialog):
         for item in skipped_list:
             self.skipped_list.addItem(item.decode("utf-8", errors="ignore"))
 
-        self.successful_label.setText(f"Successful ({len(success_list)})")
-        self.failed_label.setText(f"{self.failed_name} ({len(failed_list)})")
-        self.skipped_label.setText(f"Skipped ({len(skipped_list)})")
+        self.successful_label.setText(self.count_label(self.tr("Successful"), len(success_list)))
+        self.failed_label.setText(self.count_label(self.failed_name, len(failed_list)))
+        self.skipped_label.setText(self.count_label(self.tr("Skipped"), len(skipped_list)))
 
     def update_status(self, status: str) -> None:
         self.status_edit.showMessage(status)

--- a/nitrokeyapp/secrets_tab/ui.py
+++ b/nitrokeyapp/secrets_tab/ui.py
@@ -23,14 +23,16 @@ class PinUi(QObject):
         logger.info(f"Querying secrets PIN (remaining attempts: {attempts})")
 
         if attempts <= 2:
-            title = f"Enter Passwords PIN — {attempts} attempt(s) remaining"
-            message = (
-                f"Enter the Passwords PIN.\n\n"
-                f"WARNING: Only {attempts} attempt(s) remaining before the device locks permanently."
+            title = self.tr("Enter Passwords PIN - %n attempt(s) remaining", "", attempts)
+            message = self.tr(
+                "Enter the Passwords PIN.\n\n"
+                "WARNING: only %n attempt(s) remaining before the device locks permanently.",
+                "",
+                attempts,
             )
         else:
-            title = "Enter Passwords PIN"
-            message = f"Enter the Passwords PIN ({attempts} attempts remaining):"
+            title = self.tr("Enter Passwords PIN")
+            message = self.tr("Enter the Passwords PIN (%n attempt(s) remaining):", "", attempts)
 
         pin, ok = QInputDialog.getText(self.app_widget, title, message, QLineEdit.EchoMode.Password)
         if ok and pin:
@@ -45,8 +47,8 @@ class PinUi(QObject):
         logger.info("Prompting user to set secrets PIN")
         pin, ok = QInputDialog.getText(
             self.app_widget,
-            "Set Passwords PIN",
-            "Please enter the new PIN for Passwords:",
+            self.tr("Set Passwords PIN"),
+            self.tr("Please enter the new PIN for Passwords:"),
             QLineEdit.EchoMode.Password,
         )
         if not (ok and pin):
@@ -56,8 +58,8 @@ class PinUi(QObject):
 
         confirm_pin, ok = QInputDialog.getText(
             self.app_widget,
-            "Confirm Passwords PIN",
-            "Please confirm the new PIN for Passwords:",
+            self.tr("Confirm Passwords PIN"),
+            self.tr("Please confirm the new PIN for Passwords:"),
             QLineEdit.EchoMode.Password,
         )
         if not (ok and confirm_pin):
@@ -69,8 +71,8 @@ class PinUi(QObject):
             logger.warning("PIN confirmation mismatch — not setting PIN")
             QMessageBox.warning(
                 self.app_widget,
-                "PIN Mismatch",
-                "The PINs you entered do not match. The PIN has not been changed.",
+                self.tr("PIN Mismatch"),
+                self.tr("The PINs you entered do not match. The PIN has not been changed."),
             )
             self.cancelled.emit()
             return

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import QWidget
 
 from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
+from nitrokeyapp.error_messages import passwords_unsupported_message, user_message
 from nitrokeyapp.worker import Job, Worker
 
 from .data import Credential, OtpData, OtpKind
@@ -120,7 +121,7 @@ class VerifyPinJob(Job):
     def run(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             select = secrets.select()
@@ -140,7 +141,7 @@ class VerifyPinJob(Job):
     def pin_queried(self, pin: str) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             try:
@@ -152,13 +153,13 @@ class VerifyPinJob(Job):
                 logger.warning(f"Secrets PIN verification failed: {e}")
                 self.pin_cache.clear()
                 # TODO: repeat on failure
-                self.trigger_error("Incorrect PIN. Please try again.")
+                self.trigger_error(user_message(e))
 
     @Slot(str)
     def pin_chosen(self, pin: str) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -168,7 +169,7 @@ class VerifyPinJob(Job):
         if select.pin_attempt_counter:
             self.pin_queried(pin)
         else:
-            self.trigger_error("Failed to set Secrets PIN")
+            self.trigger_error(self.tr("The Passwords PIN could not be set."))
 
     @Slot(str)
     def trigger_error(self, msg: str) -> None:
@@ -216,11 +217,17 @@ class EditCredentialJob(Job):
         # ids = set([credential.id for credential in credentials])
 
         if self.old_cred_id not in self.all_credentials:
-            self.trigger_error(f"A credential with the name {self.old_cred_id!r} does not exists.")
+            self.trigger_error(
+                self.tr("There is no credential named '{0}'.").format(
+                    self.old_cred_id.decode(errors="replace")
+                )
+            )
             return
 
         if self.credential.id != self.old_cred_id and self.credential.id in self.all_credentials:
-            self.trigger_error(f"A credential named '{self.credential.name}' already exists.")
+            self.trigger_error(
+                self.tr("A credential named '{0}' already exists.").format(self.credential.name)
+            )
             return
 
         if self.credential.protected:
@@ -304,7 +311,7 @@ class EditCredentialJob(Job):
     def edit_credential_final(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -365,7 +372,9 @@ class AddCredentialJob(Job):
     def check_credential(self, credentials: list[Credential]) -> None:
         ids = {credential.id for credential in credentials}
         if self.credential.id in ids:
-            self.trigger_error(f"A credential with the name {self.credential.name} already exists.")
+            self.trigger_error(
+                self.tr("A credential named '{0}' already exists.").format(self.credential.name)
+            )
         elif self.credential.protected:
             verify_pin_job = VerifyPinJob(
                 self.common_ui,
@@ -387,11 +396,11 @@ class AddCredentialJob(Job):
 
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
 
             if self.credential.uri and self.credential.id:
-                self.trigger_error("Other fields must be empty if URI is used")
+                self.trigger_error(self.tr("All other fields have to be empty when a URI is used."))
 
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -471,7 +480,7 @@ class DeleteCredentialJob(Job):
     def delete_credential(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             try:
@@ -517,7 +526,7 @@ class GenerateOtpJob(Job):
     def generate_otp(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
 
@@ -574,7 +583,7 @@ class ListCredentialsJob(Job):
         else:
             with self.data.open() as device:
                 if not isinstance(device, NK3):
-                    self.trigger_error("This device does not support Passwords")
+                    self.trigger_error(passwords_unsupported_message())
                     return
                 secrets = SecretsApp(device)
                 credentials = Credential.list(secrets)
@@ -588,7 +597,7 @@ class ListCredentialsJob(Job):
 
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             for credential in Credential.list(secrets):
@@ -632,7 +641,7 @@ class GetCredentialJob(Job):
     def get_credential(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             try:

--- a/nitrokeyapp/settings_tab/__init__.py
+++ b/nitrokeyapp/settings_tab/__init__.py
@@ -4,7 +4,7 @@ from enum import Enum
 from fido2.ctap2.base import Info
 from nitrokey.nk3.secrets_app import SelectResponse
 from nitrokey.trussed import Model, Transport, TrussedDevice
-from PySide6.QtCore import QThread, Signal, Slot
+from PySide6.QtCore import QCoreApplication, QThread, Signal, Slot
 from PySide6.QtGui import QAction, QBrush, QColor, QFont
 from PySide6.QtWidgets import QLineEdit, QTreeWidgetItem, QWidget
 
@@ -36,44 +36,66 @@ RESET_ICON = QtUtilsMixIn.get_qicon("refresh.svg")
 SHOW_ICON = QtUtilsMixIn.get_qicon("visibility.svg")
 HIDE_ICON = QtUtilsMixIn.get_qicon("visibility_off.svg")
 
-SETTINGS: dict[State, dict] = {
-    State.Fido: {
-        "parent": None,
-        "icon": None,
-        "name": "FIDO2",
-        "desc": "FIDO2 is an authentication standard that enables secure "
-        + "and passwordless access to online services. It uses public "
-        + "key cryptography to provide strong authentication and "
-        + "protect against phishing and other security threats.",
-    },
-    State.FidoPin: {"parent": State.Fido, "icon": PIN_ICON, "name": "Pin Change"},
-    State.FidoReset: {
-        "parent": State.Fido,
-        "icon": RESET_ICON,
-        "name": "Factory Reset",
-        "desc": "During a FIDO reset, the password is not set. All "
-        + "previously set credentials are removed. "
-        + "Any existing authentication data, such as U2F, Passkeys and FIDO2 "
-        + "authentication factors are deleted. After the reset, the user "
-        + "will need to re-register or re-enroll their authentication "
-        + "credentials to access the system or service again.",
-    },
-    State.Passwords: {
-        "parent": None,
-        "icon": None,
-        "name": "Passwords",
-        "desc": "Within Passwords various credentials and 2FAs like OTPs can "
-        + "be stored and managed. Supported are: Plain usernames using a "
-        + "password, HOTPs, TOTPs, ReverseHOTPs and HMAC.",
-    },
-    State.PasswordsPin: {"parent": State.Passwords, "icon": PIN_ICON, "name": "Pin Change"},
-    State.PasswordsReset: {
-        "parent": State.Passwords,
-        "icon": RESET_ICON,
-        "name": "Factory Reset",
-        "desc": "This operation will inevitably remove all your credentials in Passwords!",
-    },
-}
+
+def settings_entries() -> dict[State, dict]:
+    return {
+        State.Fido: {
+            "parent": None,
+            "icon": None,
+            "name": "FIDO2",
+            "desc": QCoreApplication.translate(
+                "SettingsTab",
+                "FIDO2 is an authentication standard that enables secure "
+                "and passwordless access to online services. It uses public "
+                "key cryptography to provide strong authentication and "
+                "protect against phishing and other security threats.",
+            ),
+        },
+        State.FidoPin: {
+            "parent": State.Fido,
+            "icon": PIN_ICON,
+            "name": QCoreApplication.translate("SettingsTab", "PIN Change"),
+        },
+        State.FidoReset: {
+            "parent": State.Fido,
+            "icon": RESET_ICON,
+            "name": QCoreApplication.translate("SettingsTab", "Factory Reset"),
+            "desc": QCoreApplication.translate(
+                "SettingsTab",
+                "During a FIDO reset, the password is not set. All "
+                "previously set credentials are removed. "
+                "Any existing authentication data, such as U2F, Passkeys and FIDO2 "
+                "authentication factors are deleted. After the reset, the user "
+                "will need to re-register or re-enroll their authentication "
+                "credentials to access the system or service again.",
+            ),
+        },
+        State.Passwords: {
+            "parent": None,
+            "icon": None,
+            "name": QCoreApplication.translate("SettingsTab", "Passwords"),
+            "desc": QCoreApplication.translate(
+                "SettingsTab",
+                "Within Passwords various credentials and 2FAs like OTPs can "
+                "be stored and managed. Supported are: Plain usernames using a "
+                "password, HOTPs, TOTPs, ReverseHOTPs and HMAC.",
+            ),
+        },
+        State.PasswordsPin: {
+            "parent": State.Passwords,
+            "icon": PIN_ICON,
+            "name": QCoreApplication.translate("SettingsTab", "PIN Change"),
+        },
+        State.PasswordsReset: {
+            "parent": State.Passwords,
+            "icon": RESET_ICON,
+            "name": QCoreApplication.translate("SettingsTab", "Factory Reset"),
+            "desc": QCoreApplication.translate(
+                "SettingsTab",
+                "This operation will inevitably remove all your credentials in Passwords!",
+            ),
+        },
+    }
 
 
 class SettingsTab(QtUtilsMixIn, QWidget):
@@ -130,9 +152,10 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         self.ui.btn_reset.pressed.connect(self.reset_action)
 
         self.items = {}
+        self.settings = settings_entries()
 
         # top-lvl items
-        for state, data in SETTINGS.items():
+        for state, data in self.settings.items():
             if data.get("parent") is None:
                 item = QTreeWidgetItem(self.ui.settings_tree)
                 item.setText(0, data["name"].upper())
@@ -146,7 +169,7 @@ class SettingsTab(QtUtilsMixIn, QWidget):
                 self.items[state] = item
 
         # sub-items
-        for state, data in SETTINGS.items():
+        for state, data in self.settings.items():
             if data.get("parent") is not None:
                 item = QTreeWidgetItem(self.items[data["parent"]])
                 item.setText(0, data["name"])
@@ -172,7 +195,7 @@ class SettingsTab(QtUtilsMixIn, QWidget):
 
     @property
     def title(self) -> str:
-        return "Settings"
+        return self.tr("Settings")
 
     @property
     def widget(self) -> QWidget:
@@ -297,7 +320,7 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         self.ui.btn_save.hide()
 
         state = item.data(1, 0)
-        tmpl = SETTINGS[state]
+        tmpl = self.settings[state]
         name = tmpl.get("name")
         desc = tmpl.get("desc")
 
@@ -311,7 +334,7 @@ class SettingsTab(QtUtilsMixIn, QWidget):
 
     def view_edit_pin(self, item: QTreeWidgetItem) -> None:
         state = item.data(1, 0)
-        tmpl = SETTINGS[state]
+        tmpl = self.settings[state]
 
         self.show_current_password(False)
 
@@ -334,17 +357,17 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         self.ui.btn_save.show()
 
         self.ui.btn_save.setEnabled(False)
-        self.ui.btn_save.setToolTip("Cannot save")
+        self.ui.btn_save.setToolTip(self.tr("Cannot save"))
 
-        name = SETTINGS[SETTINGS[state]["parent"]]["name"]
+        name = self.settings[self.settings[state]["parent"]]["name"]
         name += " | " + tmpl["name"]
         self.ui.headline_label.setText(name)
 
     def view_reset(self, item: QTreeWidgetItem) -> None:
         state = item.data(1, 0)
-        tmpl = SETTINGS[state]
+        tmpl = self.settings[state]
 
-        name = SETTINGS[SETTINGS[state]["parent"]]["name"]
+        name = self.settings[self.settings[state]["parent"]]["name"]
         name += " | " + tmpl["name"]
         desc = tmpl.get("desc")
 
@@ -359,7 +382,10 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         self.ui.btn_save.hide()
 
         self.ui.warning_label.setText(
-            "**Reset for FIDO 2 is only possible within 10secs after plugging in the device.**"
+            self.tr(
+                "**Reset for FIDO2 is only possible within 10 seconds "
+                "after plugging in the device.**"
+            )
         )
 
         if state == State.FidoReset:
@@ -394,7 +420,9 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         if state == State.FidoPin:
             self.trigger_fido_change_pw.emit(self.data, old_pin, new_pin)
             self.field_clear()
-            self.common_ui.info.info.emit("done - please use new pin to verify key")
+            self.common_ui.info.info.emit(
+                self.tr("Done - please use the new PIN to verify the key")
+            )
         elif state == State.PasswordsPin:
             self.trigger_passwords_change_pw.emit(self.data, old_pin, new_pin)
             self.field_clear()
@@ -460,10 +488,10 @@ class SettingsTab(QtUtilsMixIn, QWidget):
 
         if show:
             self.ui.current_password.setEnabled(True)
-            self.ui.current_password.setPlaceholderText("<insert old PIN>")
+            self.ui.current_password.setPlaceholderText(self.tr("<insert old PIN>"))
         else:
             self.ui.current_password.setEnabled(False)
-            self.ui.current_password.setPlaceholderText("<No PIN Set>")
+            self.ui.current_password.setPlaceholderText(self.tr("<no PIN set>"))
 
     @Slot(Info, int)
     def handle_status_fido(self, fido_state: Info, pin_retries: int) -> None:
@@ -476,10 +504,10 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         if state in [State.Fido, State.FidoReset]:
             self.update_status_form(
                 [
-                    ("PIN set", "yes" if has_pin else "no"),
-                    ("PIN retries", str(pin_retries) if has_pin else "n/a"),
-                    ("Versions", ", ".join(fido_state.versions)),
-                    ("Extensions", ", ".join(fido_state.extensions)),
+                    (self.tr("PIN set"), self.tr("yes") if has_pin else self.tr("no")),
+                    (self.tr("PIN retries"), str(pin_retries) if has_pin else self.tr("n/a")),
+                    (self.tr("Versions"), ", ".join(fido_state.versions)),
+                    (self.tr("Extensions"), ", ".join(fido_state.extensions)),
                 ]
             )
         elif state == State.FidoPin:
@@ -494,12 +522,12 @@ class SettingsTab(QtUtilsMixIn, QWidget):
         state = self.active_item.data(1, 0)
         if state in [State.Passwords, State.PasswordsReset]:
             data = [
-                ("PIN set", "yes" if pin_set else "no"),
-                ("PIN retries", str(status.pin_attempt_counter)),
-                ("Version", status.version_str()),
+                (self.tr("PIN set"), self.tr("yes") if pin_set else self.tr("no")),
+                (self.tr("PIN retries"), str(status.pin_attempt_counter)),
+                (self.tr("Version"), status.version_str()),
             ]
             if status.serial_number is not None:
-                data += [("Serial", str(status.serial_number.hex()).upper())]
+                data += [(self.tr("Serial"), str(status.serial_number.hex()).upper())]
 
             self.update_status_form(data)
             self.show_current_password(pin_set)
@@ -531,7 +559,7 @@ class SettingsTab(QtUtilsMixIn, QWidget):
     def check_credential(self) -> None:
         self.common_ui.info.info.emit("")
 
-        tool_Tip = "Credential cannot be saved:"
+        tool_Tip = self.tr("Credential cannot be saved:")
         can_save = True
 
         new_password = self.ui.new_password.text()
@@ -552,35 +580,38 @@ class SettingsTab(QtUtilsMixIn, QWidget):
             if current_password_len <= 3:
                 can_save = False
             if current_password_len == 0:
-                tool_Tip = tool_Tip + "\n- Enter your Current Password"
+                tool_Tip = tool_Tip + "\n- " + self.tr("Enter your Current Password")
             if current_password_len >= 1:
                 self.action_current_password_show.setVisible(True)
             if current_password_len >= 1 and current_password_len <= 3:
-                self.common_ui.info.info.emit("Current Password is too short")
-                tool_Tip = tool_Tip + "\n- Current Password is too short"
+                message = self.tr("Current Password is too short")
+                self.common_ui.info.info.emit(message)
+                tool_Tip = tool_Tip + "\n- " + message
 
         if new_password_len <= 3:
             can_save = False
         if new_password_len == 0:
-            tool_Tip = tool_Tip + "\n- Enter your New Password"
+            tool_Tip = tool_Tip + "\n- " + self.tr("Enter your New Password")
         if new_password_len == 0 and current_password_len >= 4:
-            self.common_ui.info.info.emit("Enter your New Password")
+            self.common_ui.info.info.emit(self.tr("Enter your New Password"))
         if new_password_len >= 1:
             self.action_new_password_show.setVisible(True)
         if new_password_len >= 1 and new_password_len <= 3:
             can_save = False
-            self.common_ui.info.info.emit("New Password is too short")
-            tool_Tip = tool_Tip + "\n- New Password is too short"
+            message = self.tr("New Password is too short")
+            self.common_ui.info.info.emit(message)
+            tool_Tip = tool_Tip + "\n- " + message
 
         if repeat_password_len == 0:
             can_save = False
-            tool_Tip = tool_Tip + "\n- Repeat your New Password"
+            tool_Tip = tool_Tip + "\n- " + self.tr("Repeat your New Password")
         if repeat_password_len >= 1:
             self.action_repeat_password_show.setVisible(True)
         if repeat_password_len >= 1 and repeat_password != new_password:
             can_save = False
-            self.common_ui.info.info.emit("Repeat Password are not equal")
-            tool_Tip = tool_Tip + "\n- Repeat Password are not equal"
+            message = self.tr("The repeated password is not equal")
+            self.common_ui.info.info.emit(message)
+            tool_Tip = tool_Tip + "\n- " + message
             self.show_repeat_password_check.setVisible(False)
             self.show_repeat_password_false.setVisible(True)
         if repeat_password_len >= 4 and new_password == repeat_password:
@@ -589,6 +620,6 @@ class SettingsTab(QtUtilsMixIn, QWidget):
 
         self.ui.btn_save.setEnabled(can_save)
         if can_save:
-            tool_Tip = "Credential Save"
+            tool_Tip = self.tr("Save credential")
 
         self.ui.btn_save.setToolTip(tool_Tip)

--- a/nitrokeyapp/settings_tab/worker.py
+++ b/nitrokeyapp/settings_tab/worker.py
@@ -1,5 +1,6 @@
 import logging
 
+from fido2.ctap import CtapError
 from fido2.ctap2.base import Info
 from fido2.ctap2.pin import ClientPin
 from nitrokey.nk3 import NK3
@@ -8,6 +9,7 @@ from PySide6.QtCore import Signal, Slot
 
 from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
+from nitrokeyapp.error_messages import passwords_unsupported_message, user_message
 from nitrokeyapp.worker import Job, Worker
 
 logger = logging.getLogger(__name__)
@@ -51,7 +53,7 @@ class CheckPasswordsInfo(Job):
         pin_status: bool = False
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             status = secrets.select()
@@ -91,9 +93,9 @@ class SaveFidoPinJob(Job):
                     client_pin.change_pin(self.old_pin, self.new_pin)
                 else:
                     client_pin.set_pin(self.new_pin)
-                    self.common_ui.info.info.emit("FIDO2 PIN changed!")
+                    self.common_ui.info.info.emit(self.tr("FIDO2 PIN changed"))
             except Exception as e:
-                self.trigger_error(f"fido2 change_pin failed: {e}")
+                self.trigger_error(user_message(e))
         self.change_pw_fido.emit()
 
 
@@ -127,7 +129,7 @@ class SavePasswordsPinJob(Job):
         with self.touch_prompt():
             with self.data.open() as device:
                 if not isinstance(device, NK3):
-                    self.trigger_error("This device does not support Passwords")
+                    self.trigger_error(passwords_unsupported_message())
                 else:
                     secrets = SecretsApp(device)
                     try:
@@ -135,9 +137,9 @@ class SavePasswordsPinJob(Job):
                             secrets.change_pin_raw(self.old_pin, self.new_pin)
                         else:
                             secrets.set_pin_raw(self.new_pin)
-                        self.common_ui.info.info.emit("Passwords PIN changed!")
+                        self.common_ui.info.info.emit(self.tr("Passwords PIN changed"))
                     except SecretsAppException as e:
-                        self.trigger_error(f"PIN validation failed: {e}")
+                        self.trigger_error(user_message(e))
 
         self.change_pw_passwords.emit()
 
@@ -162,15 +164,19 @@ class ResetFido(Job):
             try:
                 with self.touch_prompt():
                     ctap2.reset()
-                    self.common_ui.info.info.emit("FIDO2 function reset successfully!")
-            except Exception as e:
-                a = str(e)
-                if a == "CTAP error: 0x30 - NOT_ALLOWED":
+                    self.common_ui.info.info.emit(self.tr("FIDO2 was reset successfully"))
+            except CtapError as e:
+                if e.code == CtapError.ERR.NOT_ALLOWED:
                     self.common_ui.info.error.emit(
-                        "Device connected for more than 10 sec. Re-plugging for reset!"
+                        self.tr(
+                            "The device has been connected for more than 10 seconds. "
+                            "Please re-plug it to reset FIDO2."
+                        )
                     )
                 else:
-                    self.trigger_error(f"fido2 reset failed: {e}")
+                    self.trigger_error(user_message(e))
+            except Exception as e:
+                self.trigger_error(user_message(e))
         self.reset_fido.emit()
 
 
@@ -187,15 +193,15 @@ class ResetPasswords(Job):
     def run(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
-                self.trigger_error("This device does not support Passwords")
+                self.trigger_error(passwords_unsupported_message())
                 return
             secrets = SecretsApp(device)
             try:
                 with self.touch_prompt():
                     secrets.reset()
-                    self.common_ui.info.info.emit("PASSWORDS function reset successfully!")
+                    self.common_ui.info.info.emit(self.tr("Passwords was reset successfully"))
             except SecretsAppException as e:
-                self.trigger_error(f"Passwords reset failed: {e}")
+                self.trigger_error(user_message(e))
         self.reset_passwords.emit()
 
 

--- a/nitrokeyapp/translations/nitrokeyapp_de.ts
+++ b/nitrokeyapp/translations/nitrokeyapp_de.ts
@@ -1,0 +1,1623 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>AddCredentialJob</name>
+    <message>
+        <location filename="../secrets_tab/worker.py" line="+376"/>
+        <source>A credential named &apos;{0}&apos; already exists.</source>
+        <translation>Es gibt bereits Zugangsdaten mit dem Namen „{0}“.</translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>All other fields have to be empty when a URI is used.</source>
+        <translation>Alle anderen Felder müssen leer sein, wenn eine URI verwendet wird.</translation>
+    </message>
+</context>
+<context>
+    <name>BackupRestoreUi</name>
+    <message>
+        <location filename="../secrets_tab/backup_restore_ui.py" line="+33"/>
+        <source>Backup</source>
+        <translation>Sicherung</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Restore</source>
+        <translation>Wiederherstellung</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Action: {0}</source>
+        <translation>Aktion: {0}</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Cleartext</source>
+        <translation>Klartext</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>This option disables encryption of the generated backup and is discouraged. Only use it for interoperability with other password managers.</source>
+        <translation>Diese Option deaktiviert die Verschlüsselung der erzeugten Sicherung und wird nicht empfohlen. Verwenden Sie sie nur zur Kompatibilität mit anderen Passwort-Managern.</translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The passphrase is created automatically during an encrypted backup.</source>
+        <translation>Die Passphrase wird bei einer verschlüsselten Sicherung automatisch erzeugt.</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Copy passphrase</source>
+        <translation>Passphrase kopieren</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Begin</source>
+        <translation>Starten</translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Passphrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Not passwords</source>
+        <translation>Keine Passwörter</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Already exists</source>
+        <translation>Bereits vorhanden</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+77"/>
+        <source>Successful</source>
+        <translation>Erfolgreich</translation>
+    </message>
+    <message>
+        <location line="-75"/>
+        <source>The operation on these credentials completed successfully</source>
+        <translation>Der Vorgang für diese Zugangsdaten wurde erfolgreich abgeschlossen</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Credentials without a password (for example OTP only) are skipped during the backup, as they cannot be extracted from the device.</source>
+        <translation>Zugangsdaten ohne Passwort (zum Beispiel nur OTP) werden bei der Sicherung übersprungen, da sie nicht vom Gerät ausgelesen werden können.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Credentials that were not imported because a credential with the same label already exists on the device</source>
+        <translation>Zugangsdaten, die nicht importiert wurden, weil auf dem Gerät bereits Zugangsdaten mit demselben Namen vorhanden sind</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+61"/>
+        <source>Skipped</source>
+        <translation>Übersprungen</translation>
+    </message>
+    <message>
+        <location line="-59"/>
+        <source>Credentials are skipped if they are PIN protected but no PIN was supplied.</source>
+        <translation>Zugangsdaten werden übersprungen, wenn sie PIN-geschützt sind, aber keine PIN angegeben wurde.</translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>{0} ({1})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Passphrase copied</source>
+        <translation>Passphrase kopiert</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Nothing to copy</source>
+        <translation>Nichts zu kopieren</translation>
+    </message>
+</context>
+<context>
+    <name>DeleteCredentialJob</name>
+    <message>
+        <location filename="../fido2_tab/worker.py" line="+225"/>
+        <source>No FIDO2 PIN is set on this device</source>
+        <translation>Auf diesem Gerät ist keine FIDO2-PIN gesetzt</translation>
+    </message>
+    <message>
+        <location line="+41"/>
+        <source>The passkey could not be deleted.</source>
+        <translation>Der Passkey konnte nicht gelöscht werden.</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Passkey deleted</source>
+        <translation>Passkey gelöscht</translation>
+    </message>
+</context>
+<context>
+    <name>EditCredentialJob</name>
+    <message>
+        <location filename="../secrets_tab/worker.py" line="-182"/>
+        <source>There is no credential named &apos;{0}&apos;.</source>
+        <translation>Es gibt keine Zugangsdaten mit dem Namen „{0}“.</translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>A credential named &apos;{0}&apos; already exists.</source>
+        <translation>Es gibt bereits Zugangsdaten mit dem Namen „{0}“.</translation>
+    </message>
+</context>
+<context>
+    <name>ErrorDialog</name>
+    <message>
+        <location filename="../error_dialog.py" line="+21"/>
+        <source>Save Log File</source>
+        <translation>Protokoll speichern</translation>
+    </message>
+    <message>
+        <location filename="../ui/error_dialog.ui" line="+14"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>An unexpected error occured.</source>
+        <translation>Ein unerwarteter Fehler ist aufgetreten.</translation>
+    </message>
+</context>
+<context>
+    <name>Fido2PinUi</name>
+    <message>
+        <location filename="../fido2_tab/ui.py" line="+22"/>
+        <source>Enter FIDO2 PIN</source>
+        <translation>FIDO2-PIN eingeben</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Please enter the FIDO2 PIN (remaining retries: {0}):</source>
+        <translation>Bitte geben Sie die FIDO2-PIN ein (verbleibende Versuche: {0}):</translation>
+    </message>
+</context>
+<context>
+    <name>Fido2Tab</name>
+    <message>
+        <location filename="../fido2_tab/__init__.py" line="+92"/>
+        <source>Display Name:</source>
+        <translation>Anzeigename:</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Username:</source>
+        <translation>Benutzername:</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Credential ID:</source>
+        <translation>Credential-ID:</translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>Passkeys</source>
+        <translation>Passkeys</translation>
+    </message>
+    <message>
+        <location line="+114"/>
+        <source>(unknown)</source>
+        <translation>(unbekannt)</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>(not set)</source>
+        <translation>(nicht gesetzt)</translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Delete Passkey</source>
+        <translation>Passkey löschen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Permanently delete the passkey &apos;{0}&apos; from this device?</source>
+        <translation>Passkey „{0}“ endgültig von diesem Gerät löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>GUI</name>
+    <message>
+        <location filename="../gui.py" line="+41"/>
+        <source>Managing passkeys requires administrator privileges on Windows. Please restart the Nitrokey App as administrator to list or delete passkeys.</source>
+        <translation>Das Verwalten von Passkeys erfordert unter Windows Administratorrechte. Bitte starten Sie die Nitrokey App als Administrator neu, um Passkeys anzuzeigen oder zu löschen.</translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>A firmware update is in progress. Please wait until it has finished before closing the application.</source>
+        <translation>Ein Firmware-Update läuft. Bitte warten Sie, bis es abgeschlossen ist, bevor Sie die Anwendung schließen.</translation>
+    </message>
+</context>
+<context>
+    <name>InfoBox</name>
+    <message>
+        <location filename="../information_box.py" line="+93"/>
+        <source>Press your Nitrokey to confirm...</source>
+        <translation>Drücken Sie Ihren Nitrokey zur Bestätigung ...</translation>
+    </message>
+    <message>
+        <location line="+28"/>
+        <source>Passwords PIN is cached - click to clear</source>
+        <translation>Passwörter-PIN ist zwischengespeichert – zum Löschen klicken</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Passwords PIN locked</source>
+        <translation>Passwörter-PIN gesperrt</translation>
+    </message>
+</context>
+<context>
+    <name>ListCredentialsJob</name>
+    <message>
+        <location filename="../fido2_tab/worker.py" line="-128"/>
+        <source>No FIDO2 PIN is set on this device</source>
+        <translation>Auf diesem Gerät ist keine FIDO2-PIN gesetzt</translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>The passkeys could not be read from the device.</source>
+        <translation>Die Passkeys konnten nicht vom Gerät gelesen werden.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="+29"/>
+        <source>Nitrokey App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+102"/>
+        <source>Test Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+97"/>
+        <source>Please insert
+ your Nitrokey</source>
+        <translation>Bitte stecken Sie
+Ihren Nitrokey ein</translation>
+    </message>
+    <message>
+        <location line="+86"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;home&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location line="+53"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;help&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hilfe&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Nk3Button</name>
+    <message>
+        <location filename="../nk3_button.py" line="+106"/>
+        <source>Touch your Nitrokey 3</source>
+        <translation>Berühren Sie Ihren Nitrokey 3</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewTab</name>
+    <message>
+        <location filename="../overview_tab/__init__.py" line="+60"/>
+        <source>Overview</source>
+        <translation>Übersicht</translation>
+    </message>
+    <message>
+        <location line="+26"/>
+        <source>Update your Nitrokey 3 for full functionality</source>
+        <translation>Aktualisieren Sie Ihren Nitrokey 3 für den vollen Funktionsumfang</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Nitrokey 3 (old firmware)</source>
+        <translation>Nitrokey 3 (alte Firmware)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>{0} Bootloader</source>
+        <translation>{0}-Bootloader</translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Please restart the application as an administrator to be able to update.</source>
+        <translation>Bitte starten Sie die Anwendung als Administrator neu, um aktualisieren zu können.</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Please remove all Nitrokey devices except the one you want to update.</source>
+        <translation>Bitte entfernen Sie alle Nitrokey-Geräte außer dem, das aktualisiert werden soll.</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Update is already running. Please wait.</source>
+        <translation>Das Update läuft bereits. Bitte warten.</translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>{0} successfully updated</source>
+        <translation>{0} erfolgreich aktualisiert</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>{0} update failed</source>
+        <translation>{0}-Update fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <source>{0} update aborted</source>
+        <translation>{0}-Update abgebrochen</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>{0}: {1}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/overview_tab.ui" line="+20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+132"/>
+        <source>Nitrokey 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>UUID:</source>
+        <translation>UUID:</translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <location line="+42"/>
+        <location line="+42"/>
+        <location line="+42"/>
+        <location line="+44"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-143"/>
+        <source>Path:</source>
+        <translation>Pfad:</translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Version:</source>
+        <translation>Version:</translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Variant:</source>
+        <translation>Variante:</translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Init status:</source>
+        <translation>Init-Status:</translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An error occurred during device initialization. &lt;br/&gt;Click &lt;span style=&quot; font-weight:600; text-decoration: underline; color:#c0392b;&quot;&gt;More Info&lt;/span&gt; for more information and contact support if the error persists.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bei der Initialisierung des Geräts ist ein Fehler aufgetreten. &lt;br/&gt;Klicken Sie auf &lt;span style=&quot; font-weight:600; text-decoration: underline; color:#c0392b;&quot;&gt;Mehr Infos&lt;/span&gt; für weitere Informationen und wenden Sie sich an den Support, falls der Fehler bestehen bleibt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://docs.nitrokey.com/nitrokey3/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0392b;&quot;&gt;More Info&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://docs.nitrokey.com/nitrokey3/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0392b;&quot;&gt;Mehr Infos&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location line="+48"/>
+        <source>Check for Update</source>
+        <translation>Nach Update suchen</translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Update with local Firmware</source>
+        <translation>Mit lokaler Firmware aktualisieren</translation>
+    </message>
+</context>
+<context>
+    <name>PinUi</name>
+    <message numerus="yes">
+        <location filename="../secrets_tab/ui.py" line="+26"/>
+        <source>Enter Passwords PIN - %n attempt(s) remaining</source>
+        <translation>
+            <numerusform>Passwörter-PIN eingeben – noch %n Versuch</numerusform>
+            <numerusform>Passwörter-PIN eingeben – noch %n Versuche</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+2"/>
+        <source>Enter the Passwords PIN.
+
+WARNING: only %n attempt(s) remaining before the device locks permanently.</source>
+        <translation>
+            <numerusform>Geben Sie die Passwörter-PIN ein.
+
+WARNUNG: Nur noch %n Versuch, bevor das Gerät dauerhaft gesperrt wird.</numerusform>
+            <numerusform>Geben Sie die Passwörter-PIN ein.
+
+WARNUNG: Nur noch %n Versuche, bevor das Gerät dauerhaft gesperrt wird.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Enter Passwords PIN</source>
+        <translation>Passwörter-PIN eingeben</translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>Enter the Passwords PIN (%n attempt(s) remaining):</source>
+        <translation>
+            <numerusform>Geben Sie die Passwörter-PIN ein (noch %n Versuch):</numerusform>
+            <numerusform>Geben Sie die Passwörter-PIN ein (noch %n Versuche):</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Set Passwords PIN</source>
+        <translation>Passwörter-PIN festlegen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Please enter the new PIN for Passwords:</source>
+        <translation>Bitte geben Sie die neue PIN für Passwörter ein:</translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Confirm Passwords PIN</source>
+        <translation>Passwörter-PIN bestätigen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Please confirm the new PIN for Passwords:</source>
+        <translation>Bitte bestätigen Sie die neue PIN für Passwörter:</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PIN Mismatch</source>
+        <translation>PINs stimmen nicht überein</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The PINs you entered do not match. The PIN has not been changed.</source>
+        <translation>Die eingegebenen PINs stimmen nicht überein. Die PIN wurde nicht geändert.</translation>
+    </message>
+</context>
+<context>
+    <name>ResetFido</name>
+    <message>
+        <location filename="../settings_tab/worker.py" line="+167"/>
+        <source>FIDO2 was reset successfully</source>
+        <translation>FIDO2 wurde erfolgreich zurückgesetzt</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The device has been connected for more than 10 seconds. Please re-plug it to reset FIDO2.</source>
+        <translation>Das Gerät ist seit mehr als 10 Sekunden angeschlossen. Bitte stecken Sie es neu ein, um FIDO2 zurückzusetzen.</translation>
+    </message>
+</context>
+<context>
+    <name>ResetPasswords</name>
+    <message>
+        <location line="+30"/>
+        <source>Passwords was reset successfully</source>
+        <translation>Passwörter wurde erfolgreich zurückgesetzt</translation>
+    </message>
+</context>
+<context>
+    <name>SaveFidoPinJob</name>
+    <message>
+        <location line="-106"/>
+        <source>FIDO2 PIN changed</source>
+        <translation>FIDO2-PIN geändert</translation>
+    </message>
+</context>
+<context>
+    <name>SavePasswordsPinJob</name>
+    <message>
+        <location line="+44"/>
+        <source>Passwords PIN changed</source>
+        <translation>Passwörter-PIN geändert</translation>
+    </message>
+</context>
+<context>
+    <name>SecretsTab</name>
+    <message>
+        <location filename="../secrets_tab/__init__.py" line="+217"/>
+        <source>Generate random password</source>
+        <translation>Zufälliges Passwort erzeugen</translation>
+    </message>
+    <message>
+        <location line="+99"/>
+        <source>Passwords</source>
+        <translation>Passwörter</translation>
+    </message>
+    <message>
+        <location line="+101"/>
+        <source>Secret is generated</source>
+        <translation>Secret wurde erzeugt</translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Backup passwords</source>
+        <translation>Passwörter sichern</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Save Credential Backup</source>
+        <translation>Sicherung der Zugangsdaten speichern</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+11"/>
+        <source>JSON Files (*.json)</source>
+        <translation>JSON-Dateien (*.json)</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Open Credential Backup</source>
+        <translation>Sicherung der Zugangsdaten öffnen</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Restore passwords from {0}</source>
+        <translation>Passwörter aus {0} wiederherstellen</translation>
+    </message>
+    <message>
+        <location line="+124"/>
+        <location line="+493"/>
+        <source>&lt;hidden&gt;</source>
+        <translation>&lt;verborgen&gt;</translation>
+    </message>
+    <message>
+        <location line="-397"/>
+        <source>&lt;hidden - click to edit&gt;</source>
+        <translation>&lt;verborgen – zum Bearbeiten klicken&gt;</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>&lt;cannot edit&gt;</source>
+        <translation>&lt;nicht bearbeitbar&gt;</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <location line="+17"/>
+        <location line="+41"/>
+        <location line="+92"/>
+        <location filename="../ui/secrets_tab.ui" line="+436"/>
+        <location line="+44"/>
+        <location line="+42"/>
+        <location line="+39"/>
+        <location line="+135"/>
+        <source>&lt;empty&gt;</source>
+        <translation>&lt;leer&gt;</translation>
+    </message>
+    <message>
+        <location line="-48"/>
+        <source>Credential cannot be saved:</source>
+        <translation>Zugangsdaten können nicht gespeichert werden:</translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <location line="+1"/>
+        <source>Enter a Credential Name</source>
+        <translation>Geben Sie einen Namen ein</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+1"/>
+        <source>Credential Name is too short</source>
+        <translation>Der Name ist zu kurz</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+1"/>
+        <source>Credential Name is too long</source>
+        <translation>Der Name ist zu lang</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+1"/>
+        <source>Username is too long</source>
+        <translation>Der Benutzername ist zu lang</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+1"/>
+        <source>Password is too long</source>
+        <translation>Das Passwort ist zu lang</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+1"/>
+        <source>Comment is too long</source>
+        <translation>Der Kommentar ist zu lang</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>OTP not configured</source>
+        <translation>OTP nicht eingerichtet</translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <location line="+3"/>
+        <source>The HMAC-Secret is not 32 chars long</source>
+        <translation>Das HMAC-Secret ist nicht 32 Zeichen lang</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <location line="+1"/>
+        <location line="+8"/>
+        <location line="+1"/>
+        <source>Invalid character in Secret</source>
+        <translation>Ungültiges Zeichen im Secret</translation>
+    </message>
+    <message>
+        <location line="-6"/>
+        <location line="+1"/>
+        <source>Secret is not in Base32</source>
+        <translation>Das Secret ist nicht Base32-kodiert</translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+1"/>
+        <source>Secret is not valid Base32</source>
+        <translation>Das Secret ist kein gültiges Base32</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+1"/>
+        <source>Enter a Secret</source>
+        <translation>Geben Sie ein Secret ein</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Save credential</source>
+        <translation>Zugangsdaten speichern</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Contents copied to clipboard</source>
+        <translation>In die Zwischenablage kopiert</translation>
+    </message>
+    <message>
+        <location line="+67"/>
+        <source>Select at least one character group to generate a password</source>
+        <translation>Wählen Sie mindestens eine Zeichengruppe aus, um ein Passwort zu erzeugen</translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Letters</source>
+        <translation>Buchstaben</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Digits</source>
+        <translation>Ziffern</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Symbols</source>
+        <translation>Sonderzeichen</translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Length:</source>
+        <translation>Länge:</translation>
+    </message>
+    <message>
+        <location line="+122"/>
+        <source>Delete Credential</source>
+        <translation>Zugangsdaten löschen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Delete &apos;{0}&apos; from the device?</source>
+        <translation>„{0}“ vom Gerät löschen?</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This action cannot be undone.</source>
+        <translation>Diese Aktion kann nicht rückgängig gemacht werden.</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location filename="../ui/secrets_tab.ui" line="+206"/>
+        <source>Delete</source>
+        <translation>Löschen</translation>
+    </message>
+    <message>
+        <location line="+73"/>
+        <source>Idle</source>
+        <translation>Bereit</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Backup complete</source>
+        <translation>Sicherung abgeschlossen</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Restore complete</source>
+        <translation>Wiederherstellung abgeschlossen</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Working... Press your Nitrokey if it blinks.</source>
+        <translation>Vorgang läuft ... Drücken Sie Ihren Nitrokey, wenn er blinkt.</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The backup is encrypted. Please enter the passphrase.</source>
+        <translation>Die Sicherung ist verschlüsselt. Bitte geben Sie die Passphrase ein.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The backup is not encrypted, the passphrase is ignored.</source>
+        <translation>Die Sicherung ist nicht verschlüsselt, die Passphrase wird ignoriert.</translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>The backup file could not be read.</source>
+        <translation>Die Sicherungsdatei konnte nicht gelesen werden.</translation>
+    </message>
+    <message>
+        <location filename="../ui/secrets_tab.ui" line="-882"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+93"/>
+        <source>Refresh</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <source>Export</source>
+        <translation>Exportieren</translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>Import</source>
+        <translation>Importieren</translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Show Protected Passwords</source>
+        <translation>Geschützte Passwörter anzeigen</translation>
+    </message>
+    <message>
+        <location line="+116"/>
+        <source>dummy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>&lt;insert credential name&gt;</source>
+        <translation>&lt;Namen eingeben&gt;</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>URI:</source>
+        <translation>URI:</translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>Username:</source>
+        <translation>Benutzername:</translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Password:</source>
+        <translation>Passwort:</translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Comment:</source>
+        <translation>Kommentar:</translation>
+    </message>
+    <message>
+        <location line="+73"/>
+        <location line="+13"/>
+        <source>Password only</source>
+        <translation>Nur Passwort</translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+52"/>
+        <source>%v s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Require PIN:</source>
+        <translation>PIN erforderlich:</translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Require Touch:</source>
+        <translation>Berührung erforderlich:</translation>
+    </message>
+    <message>
+        <location line="+100"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>Save</source>
+        <translation>Speichern</translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>Edit</source>
+        <translation>Bearbeiten</translation>
+    </message>
+    <message>
+        <location line="+48"/>
+        <source>Please update the firmware on the device to use this feature.</source>
+        <translation>Bitte aktualisieren Sie die Firmware des Geräts, um diese Funktion zu nutzen.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTab</name>
+    <message>
+        <location filename="../settings_tab/__init__.py" line="+46"/>
+        <source>FIDO2 is an authentication standard that enables secure and passwordless access to online services. It uses public key cryptography to provide strong authentication and protect against phishing and other security threats.</source>
+        <translation>FIDO2 ist ein Authentifizierungsstandard für den sicheren und passwortlosen Zugang zu Online-Diensten. Er nutzt Public-Key-Kryptografie für eine starke Authentifizierung und schützt vor Phishing und anderen Sicherheitsbedrohungen.</translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <location line="+30"/>
+        <source>PIN Change</source>
+        <translation>PIN ändern</translation>
+    </message>
+    <message>
+        <location line="-25"/>
+        <location line="+30"/>
+        <source>Factory Reset</source>
+        <translation>Werksreset</translation>
+    </message>
+    <message>
+        <location line="-29"/>
+        <source>During a FIDO reset, the password is not set. All previously set credentials are removed. Any existing authentication data, such as U2F, Passkeys and FIDO2 authentication factors are deleted. After the reset, the user will need to re-register or re-enroll their authentication credentials to access the system or service again.</source>
+        <translation>Bei einem FIDO-Reset wird kein Passwort gesetzt. Alle zuvor angelegten Zugangsdaten werden entfernt. Vorhandene Authentifizierungsdaten wie U2F, Passkeys und FIDO2-Faktoren werden gelöscht. Nach dem Zurücksetzen müssen die Zugangsdaten neu registriert werden, um wieder auf das System oder den Dienst zugreifen zu können.</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Passwords</source>
+        <translation>Passwörter</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Within Passwords various credentials and 2FAs like OTPs can be stored and managed. Supported are: Plain usernames using a password, HOTPs, TOTPs, ReverseHOTPs and HMAC.</source>
+        <translation>In Passwörter lassen sich verschiedene Zugangsdaten und 2FA-Verfahren wie OTPs speichern und verwalten. Unterstützt werden: einfache Benutzernamen mit Passwort, HOTPs, TOTPs, ReverseHOTPs und HMAC.</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>This operation will inevitably remove all your credentials in Passwords!</source>
+        <translation>Dieser Vorgang entfernt unwiderruflich alle Ihre Zugangsdaten in Passwörter!</translation>
+    </message>
+    <message>
+        <location line="+105"/>
+        <location filename="../ui/settings_tab.ui" line="+99"/>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location line="+162"/>
+        <source>Cannot save</source>
+        <translation>Speichern nicht möglich</translation>
+    </message>
+    <message>
+        <location line="+26"/>
+        <source>**Reset for FIDO2 is only possible within 10 seconds after plugging in the device.**</source>
+        <translation>**Ein Reset von FIDO2 ist nur innerhalb von 10 Sekunden nach dem Einstecken des Geräts möglich.**</translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>Done - please use the new PIN to verify the key</source>
+        <translation>Fertig – bitte bestätigen Sie den Schlüssel mit der neuen PIN</translation>
+    </message>
+    <message>
+        <location line="+67"/>
+        <source>&lt;insert old PIN&gt;</source>
+        <translation>&lt;alte PIN eingeben&gt;</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;no PIN set&gt;</source>
+        <translation>&lt;keine PIN gesetzt&gt;</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+18"/>
+        <source>PIN set</source>
+        <translation>PIN gesetzt</translation>
+    </message>
+    <message>
+        <location line="-18"/>
+        <location line="+18"/>
+        <source>yes</source>
+        <translation>ja</translation>
+    </message>
+    <message>
+        <location line="-18"/>
+        <location line="+18"/>
+        <source>no</source>
+        <translation>nein</translation>
+    </message>
+    <message>
+        <location line="-17"/>
+        <location line="+18"/>
+        <source>PIN retries</source>
+        <translation>Verbleibende PIN-Versuche</translation>
+    </message>
+    <message>
+        <location line="-18"/>
+        <source>n/a</source>
+        <translation>n. v.</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Versions</source>
+        <translation>Versionen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Extensions</source>
+        <translation>Erweiterungen</translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Serial</source>
+        <translation>Seriennummer</translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>Credential cannot be saved:</source>
+        <translation>Zugangsdaten können nicht gespeichert werden:</translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Enter your Current Password</source>
+        <translation>Geben Sie Ihr aktuelles Passwort ein</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Current Password is too short</source>
+        <translation>Das aktuelle Passwort ist zu kurz</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <location line="+2"/>
+        <source>Enter your New Password</source>
+        <translation>Geben Sie Ihr neues Passwort ein</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>New Password is too short</source>
+        <translation>Das neue Passwort ist zu kurz</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Repeat your New Password</source>
+        <translation>Wiederholen Sie Ihr neues Passwort</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The repeated password is not equal</source>
+        <translation>Die Wiederholung stimmt nicht überein</translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Save credential</source>
+        <translation>Zugangsdaten speichern</translation>
+    </message>
+    <message>
+        <location filename="../ui/settings_tab.ui" line="-79"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+133"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Reset</source>
+        <translation>Zurücksetzen</translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Save</source>
+        <translation>Speichern</translation>
+    </message>
+    <message>
+        <location line="+116"/>
+        <source>dummy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
+        <source>&lt;label 0&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>&lt;value 0&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>&lt;label 1&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>&lt;value 1&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>&lt;label 2&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>&lt;value 2&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>&lt;label 3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>&lt;value 3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>&lt;label 4&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>&lt;value 4&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>&lt;label 5&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>&lt;value 5&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Current PIN:</source>
+        <translation>Aktuelle PIN:</translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+62"/>
+        <location line="+24"/>
+        <source>&lt;empty&gt;</source>
+        <translation>&lt;leer&gt;</translation>
+    </message>
+    <message>
+        <location line="-70"/>
+        <source>New PIN:</source>
+        <translation>Neue PIN:</translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Confirm New PIN:</source>
+        <translation>Neue PIN bestätigen:</translation>
+    </message>
+    <message>
+        <location line="+72"/>
+        <source>[warning message box]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+37"/>
+        <source>[info message box]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Please update the firmware on the device to use this feature.</source>
+        <translation>Bitte aktualisieren Sie die Firmware des Geräts, um diese Funktion zu nutzen.</translation>
+    </message>
+</context>
+<context>
+    <name>VerifyPinJob</name>
+    <message>
+        <location filename="../secrets_tab/worker.py" line="-57"/>
+        <source>The Passwords PIN could not be set.</source>
+        <translation>Die Passwörter-PIN konnte nicht gesetzt werden.</translation>
+    </message>
+</context>
+<context>
+    <name>WelcomeTab</name>
+    <message>
+        <location filename="../welcome_tab.py" line="+70"/>
+        <source>The language is set to {0} by {1}.</source>
+        <translation>Die Sprache wird durch {1} auf {0} festgelegt.</translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>No connection</source>
+        <translation>Keine Verbindung</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Update available</source>
+        <translation>Update verfügbar</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>App is up to date</source>
+        <translation>App ist aktuell</translation>
+    </message>
+    <message>
+        <location filename="../ui/welcome_tab.ui" line="+20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+68"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Welcome to the Nitrokey App&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Willkommen in der Nitrokey App&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location line="+148"/>
+        <source>This application allows you to administrate your Nitrokey 3</source>
+        <translation>Mit dieser Anwendung verwalten Sie Ihren Nitrokey 3</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Your connected devices are visible on the left side</source>
+        <translation>Ihre angeschlossenen Geräte sehen Sie links</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Select the device you want to manage</source>
+        <translation>Wählen Sie das Gerät aus, das Sie verwalten möchten</translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <source>App version:</source>
+        <translation>App-Version:</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>1.0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Check for App Update</source>
+        <translation>Nach App-Update suchen</translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Language:</source>
+        <translation>Sprache:</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Restart to apply</source>
+        <translation>Neustart nötig</translation>
+    </message>
+    <message>
+        <location line="+69"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://docs.nitrokey.com/software/nk-app2/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0392b;&quot;&gt;Instructions and help&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://docs.nitrokey.com/software/nk-app2/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c0392b;&quot;&gt;Anleitung und Hilfe&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>Save Log File</source>
+        <translation>Protokoll speichern</translation>
+    </message>
+</context>
+<context>
+    <name>errors</name>
+    <message>
+        <location filename="../error_messages.py" line="+21"/>
+        <source>This device does not support Passwords.</source>
+        <translation>Dieses Gerät unterstützt Passwörter nicht.</translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>The operation failed.</source>
+        <translation>Der Vorgang ist fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The operation failed: {0}</source>
+        <translation>Der Vorgang ist fehlgeschlagen: {0}</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>There is not enough space on the internal filesystem of the device to perform the firmware update. The release notes explain how to free some up: {0}</source>
+        <translation>Auf dem internen Dateisystem des Geräts ist nicht genug Platz für das Firmware-Update. Die Release Notes erklären, wie Sie Platz schaffen: {0}</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The state of the device cannot be determined because its firmware is too old. Please update to firmware version v1.3.1 first.</source>
+        <translation>Der Zustand des Geräts lässt sich nicht ermitteln, weil seine Firmware zu alt ist. Bitte aktualisieren Sie zuerst auf Firmware-Version v1.3.1.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The Nitrokey SDK this application was built with is too old for the device. Please update the Nitrokey App and try again.</source>
+        <translation>Das Nitrokey-SDK, mit dem diese Anwendung gebaut wurde, ist zu alt für das Gerät. Bitte aktualisieren Sie die Nitrokey App und versuchen Sie es erneut.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The state of the device cannot be checked because it is already in bootloader mode. Please review the release notes before continuing: {0}</source>
+        <translation>Der Zustand des Geräts lässt sich nicht prüfen, weil es bereits im Bootloader-Modus ist. Bitte lesen Sie die Release Notes, bevor Sie fortfahren: {0}</translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>The PIN is not correct.</source>
+        <translation>Die PIN ist nicht korrekt.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The PIN is blocked because it was entered incorrectly too often. A factory reset of Passwords is needed to use it again.</source>
+        <translation>Die PIN ist gesperrt, weil sie zu oft falsch eingegeben wurde. Um sie wieder zu nutzen, ist ein Werksreset von Passwörter nötig.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PIN has to be entered before this operation.</source>
+        <translation>Für diesen Vorgang muss zuerst die PIN eingegeben werden.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The operation was not confirmed on the device.</source>
+        <translation>Der Vorgang wurde am Gerät nicht bestätigt.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The credential was not found on the device.</source>
+        <translation>Die Zugangsdaten wurden auf dem Gerät nicht gefunden.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>There is not enough space left on the device for another credential.</source>
+        <translation>Auf dem Gerät ist kein Platz für weitere Zugangsdaten.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+3"/>
+        <source>The device rejected the data sent.</source>
+        <translation>Das Gerät hat die gesendeten Daten abgelehnt.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+3"/>
+        <location line="+3"/>
+        <location line="+67"/>
+        <location line="+3"/>
+        <location line="+3"/>
+        <source>This device does not support the requested operation.</source>
+        <translation>Dieses Gerät unterstützt den angeforderten Vorgang nicht.</translation>
+    </message>
+    <message>
+        <location line="-59"/>
+        <source>The FIDO2 PIN is not correct.</source>
+        <translation>Die FIDO2-PIN ist nicht korrekt.</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The FIDO2 PIN is blocked because it was entered incorrectly too often. A factory reset of FIDO2 is needed to use it again.</source>
+        <translation>Die FIDO2-PIN ist gesperrt, weil sie zu oft falsch eingegeben wurde. Um sie wieder zu nutzen, ist ein Werksreset von FIDO2 nötig.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The FIDO2 PIN was entered incorrectly too often. Please remove the Nitrokey, insert it again and retry.</source>
+        <translation>Die FIDO2-PIN wurde zu oft falsch eingegeben. Bitte ziehen Sie den Nitrokey ab, stecken Sie ihn wieder ein und versuchen Sie es erneut.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The FIDO2 PIN authentication failed.</source>
+        <translation>Die Authentifizierung mit der FIDO2-PIN ist fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>No FIDO2 PIN is set on this device.</source>
+        <translation>Auf diesem Gerät ist keine FIDO2-PIN gesetzt.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The new FIDO2 PIN does not meet the requirements of the device.</source>
+        <translation>Die neue FIDO2-PIN erfüllt die Anforderungen des Geräts nicht.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The FIDO2 PIN has to be entered again.</source>
+        <translation>Die FIDO2-PIN muss erneut eingegeben werden.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The FIDO2 PIN has to be entered before this operation.</source>
+        <translation>Für diesen Vorgang muss zuerst die FIDO2-PIN eingegeben werden.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>There are no passkeys stored on this device.</source>
+        <translation>Auf diesem Gerät sind keine Passkeys gespeichert.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>There is no space left on the device for another passkey.</source>
+        <translation>Auf dem Gerät ist kein Platz für einen weiteren Passkey.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+3"/>
+        <source>The Nitrokey was not touched in time. Please try again.</source>
+        <translation>Der Nitrokey wurde nicht rechtzeitig berührt. Bitte versuchen Sie es erneut.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The operation has to be confirmed by touching the Nitrokey.</source>
+        <translation>Der Vorgang muss durch Berühren des Nitrokey bestätigt werden.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The device refused the operation.</source>
+        <translation>Das Gerät hat den Vorgang verweigert.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The operation was cancelled.</source>
+        <translation>Der Vorgang wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The device does not allow this operation.</source>
+        <translation>Das Gerät lässt diesen Vorgang nicht zu.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The fingerprint check is blocked. Please use the FIDO2 PIN instead.</source>
+        <translation>Die Fingerabdruckprüfung ist gesperrt. Bitte verwenden Sie stattdessen die FIDO2-PIN.</translation>
+    </message>
+</context>
+<context>
+    <name>fido2</name>
+    <message>
+        <location filename="../fido2_tab/data.py" line="+26"/>
+        <source>User verification optional</source>
+        <translation>Nutzerverifizierung optional</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>User verification optional (with credential list)</source>
+        <translation>Nutzerverifizierung optional (mit Credential-Liste)</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>User verification required</source>
+        <translation>Nutzerverifizierung erforderlich</translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>(no name)</source>
+        <translation>(kein Name)</translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>{0} stored</source>
+        <translation>{0} gespeichert</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>up to {0} free</source>
+        <translation>bis zu {0} frei</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Passkeys: {0}</source>
+        <translation>Passkeys: {0}</translation>
+    </message>
+</context>
+<context>
+    <name>i18n</name>
+    <message>
+        <location filename="../i18n.py" line="+89"/>
+        <source>System language</source>
+        <translation>Systemsprache</translation>
+    </message>
+</context>
+<context>
+    <name>logger</name>
+    <message>
+        <location filename="../logger.py" line="+70"/>
+        <source>Save Log File</source>
+        <translation>Protokoll speichern</translation>
+    </message>
+</context>
+<context>
+    <name>update</name>
+    <message>
+        <location filename="../update.py" line="+69"/>
+        <source>DANGER - you can ignore this warning by pressing OK</source>
+        <translation>ACHTUNG – Sie können diese Warnung mit OK übergehen</translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+33"/>
+        <location line="+32"/>
+        <location line="+23"/>
+        <location line="+15"/>
+        <source>The firmware update was cancelled.</source>
+        <translation>Das Firmware-Update wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location line="-95"/>
+        <source>The firmware image ({0}) is older than the firmware on the device ({1}).</source>
+        <translation>Das Firmware-Abbild ({0}) ist älter als die Firmware auf dem Gerät ({1}).</translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Do you want to download firmware version {0}?</source>
+        <translation>Möchten Sie die Firmware-Version {0} herunterladen?</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>{0} Firmware Update</source>
+        <translation>{0} Firmware-Update</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Please do not remove the {0} or insert any other {0} devices during the update. Doing so may damage the {0}.</source>
+        <translation>Bitte entfernen Sie den {0} nicht und stecken Sie während des Updates keine weiteren {0}-Geräte ein. Das kann den {0} beschädigen.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>QubesOS is detected!
+
+After the touch prompt, the {0} will be loaded into the bootloader. The Nitrokey must then be reattached to the current Qube.
+
+Do you want to perform the firmware update now?</source>
+        <translation>QubesOS wurde erkannt!
+
+Nach der Berührungsaufforderung wird der {0} in den Bootloader geladen. Der Nitrokey muss dann erneut mit der aktuellen Qube verbunden werden.
+
+Möchten Sie das Firmware-Update jetzt durchführen?</translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Do you want to perform the firmware update now?</source>
+        <translation>Möchten Sie das Firmware-Update jetzt durchführen?</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Device is in bootloader mode</source>
+        <translation>Das Gerät ist im Bootloader-Modus</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>The version of the firmware image is the same as the one on the device. Do you want to continue anyway?</source>
+        <translation>Die Version des Firmware-Abbilds ist dieselbe wie auf dem Gerät. Möchten Sie trotzdem fortfahren?</translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Confirm extra information</source>
+        <translation>Zusätzliche Informationen bestätigen</translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>This version of the Nitrokey App is too old for the update. Please install version {0} or newer.</source>
+        <translation>Diese Version der Nitrokey App ist zu alt für das Update. Bitte installieren Sie Version {0} oder neuer.</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>The device was switched to bootloader mode. Please start the firmware update again.</source>
+        <translation>Das Gerät wurde in den Bootloader-Modus versetzt. Bitte starten Sie das Firmware-Update erneut.</translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Update</source>
+        <translation>Update</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Download</source>
+        <translation>Download</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalization</source>
+        <translation>Abschluss</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>The device is no longer available.</source>
+        <translation>Das Gerät ist nicht mehr verfügbar.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Found a {0} where a {1} was expected.</source>
+        <translation>Es wurde ein {0} gefunden, erwartet wurde ein {1}.</translation>
+    </message>
+    <message>
+        <location line="+30"/>
+        <source>More than one {0} is connected. Please connect only the device that should be updated.</source>
+        <translation>Es ist mehr als ein {0} angeschlossen. Bitte schließen Sie nur das Gerät an, das aktualisiert werden soll.</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The {0} could not be found.</source>
+        <translation>Der {0} konnte nicht gefunden werden.</translation>
+    </message>
+    <message>
+        <location line="+34"/>
+        <source>The external filesystem of the device needs to be reformatted. Please contact {0} for more information on how to solve this issue.</source>
+        <translation>Das externe Dateisystem des Geräts muss neu formatiert werden. Bitte wenden Sie sich an {0}, um zu erfahren, wie Sie das Problem lösen.</translation>
+    </message>
+</context>
+<context>
+    <name>utils</name>
+    <message>
+        <location filename="../utils.py" line="+87"/>
+        <source>Missing Dependency</source>
+        <translation>Fehlende Abhängigkeit</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>{0} is set but pyscard is not installed.
+Please install it to use CCID mode.</source>
+        <translation>{0} ist gesetzt, aber pyscard ist nicht installiert.
+Bitte installieren Sie es, um den CCID-Modus zu nutzen.</translation>
+    </message>
+</context>
+</TS>

--- a/nitrokeyapp/ui/icons/dark_mode/up_arrow_colored.svg
+++ b/nitrokeyapp/ui/icons/dark_mode/up_arrow_colored.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg2"
+   width="27.735645"
+   height="27.735645"
+   viewBox="0 0 27.735645 27.735645"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+    <defs id="defs6">
+    <filter id="to-color" color-interpolation-filters="sRGB">
+      <feColorMatrix type="matrix"
+        values="0 0 0 0 0.5451
+                0 0 0 0 0.5804
+                0 0 0 0 0.6196
+                0 0 0 1 0"/>
+    </filter>
+  </defs>
+  <g
+     id="g8">
+    <image
+       width="27.735645"
+       height="27.735645"
+       preserveAspectRatio="none"
+       style="image-rendering:optimizeQuality;filter:url(#to-color)"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAA1PCAANTwgGvdNcZAAAA
+GXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAeNJREFUaIHtl0tLQlEURhc4yChC
+JCKwIDR7vx/WD20c1MRB8wYNggZBQRAIQRBEYWllar8gG7hPmVy9+6hXjc6CPfLu71sb4YrgcDgc
+DofDkzhwJBPvsYs100AWqMhkgWRPjSxIAk/8yJt54g8cMYO3vJlneaYvmaUq2Ei+9ojZHjk2ZA7I
+4S9vJic7fcE8kEcvbyYvuz1lgdbka49Y6Lq1sAi8+Ahq5kWyusoS8NqmeO28SmZXWLaQz6F7M1WA
+N8kOlBUp0ghlqb7zk/z+VfY7YiUo+VWgoBR5BBI1uwngQblbkK6OsmYhfw9MeWRMyWeajHfp7Ajr
+EqgpvgMmm2RNyjPaI9bbld8AisrCWyCmyIzJs5rMoji0xKaF/A0wbpE9LjvaIzZt5beAkrIgA4zZ
+FshORtlREicV20BZGXwNjLYgbxiVDE1XWdyakrKQvwKibcgbopKlPSLVKGgH+FAGXQKRDsgbIsCF
+svsD2K0PGET/nj8HRjoobxiRbI1DQZy/iQGfisUzYDgAecOwdPh5fAIT9csHPkunwFCA8oYh6Wrm
+cui1GALSDRZOqPvKAmZQOr1c0uLqidcRx0A4WF9PwtKtljeEgD2q/5T2gYHgHH0ZEIe8OPnKOxwO
+h8PhcPwnvgAmI7SeZzbkwAAAAABJRU5ErkJggg==
+"
+       id="image10" />
+  </g>
+</svg>

--- a/nitrokeyapp/ui/icons/dark_mode/up_arrow_colored.svg.license
+++ b/nitrokeyapp/ui/icons/dark_mode/up_arrow_colored.svg.license
@@ -1,0 +1,6 @@
+Copyright (c) Nitrokey GmbH
+SPDX-License-Identifier: Apache-2.0
+
+Source: nitrokeyapp/ui/icons/dark_mode/down_arrow_colored.svg
+
+Modified: the same chevron, rotated by 180 degrees and scaled to 48 px.

--- a/nitrokeyapp/ui/icons/light_mode/up_arrow.svg
+++ b/nitrokeyapp/ui/icons/light_mode/up_arrow.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg2"
+   width="27.735645"
+   height="27.735645"
+   viewBox="0 0 27.735645 27.735645"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6" />
+  <g
+     id="g8">
+    <image
+       width="27.735645"
+       height="27.735645"
+       preserveAspectRatio="none"
+       style="image-rendering:optimizeQuality"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAA1PCAANTwgGvdNcZAAAA
+GXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAeNJREFUaIHtl0tLQlEURhc4yChC
+JCKwIDR7vx/WD20c1MRB8wYNggZBQRAIQRBEYWllar8gG7hPmVy9+6hXjc6CPfLu71sb4YrgcDgc
+DofDkzhwJBPvsYs100AWqMhkgWRPjSxIAk/8yJt54g8cMYO3vJlneaYvmaUq2Ei+9ojZHjk2ZA7I
+4S9vJic7fcE8kEcvbyYvuz1lgdbka49Y6Lq1sAi8+Ahq5kWyusoS8NqmeO28SmZXWLaQz6F7M1WA
+N8kOlBUp0ghlqb7zk/z+VfY7YiUo+VWgoBR5BBI1uwngQblbkK6OsmYhfw9MeWRMyWeajHfp7Ajr
+EqgpvgMmm2RNyjPaI9bbld8AisrCWyCmyIzJs5rMoji0xKaF/A0wbpE9LjvaIzZt5beAkrIgA4zZ
+FshORtlREicV20BZGXwNjLYgbxiVDE1XWdyakrKQvwKibcgbopKlPSLVKGgH+FAGXQKRDsgbIsCF
+svsD2K0PGET/nj8HRjoobxiRbI1DQZy/iQGfisUzYDgAecOwdPh5fAIT9csHPkunwFCA8oYh6Wrm
+cui1GALSDRZOqPvKAmZQOr1c0uLqidcRx0A4WF9PwtKtljeEgD2q/5T2gYHgHH0ZEIe8OPnKOxwO
+h8PhcPwnvgAmI7SeZzbkwAAAAABJRU5ErkJggg==
+"
+       id="image10" />
+  </g>
+</svg>

--- a/nitrokeyapp/ui/icons/light_mode/up_arrow.svg.license
+++ b/nitrokeyapp/ui/icons/light_mode/up_arrow.svg.license
@@ -1,0 +1,6 @@
+Copyright (c) Nitrokey GmbH
+SPDX-License-Identifier: Apache-2.0
+
+Source: nitrokeyapp/ui/icons/light_mode/down_arrow.svg
+
+Modified: the same chevron, rotated by 180 degrees and scaled to 48 px.

--- a/nitrokeyapp/ui/secrets_tab.ui
+++ b/nitrokeyapp/ui/secrets_tab.ui
@@ -628,17 +628,17 @@
                     </item>
                     <item>
                      <property name="text">
-                      <string>TOTP</string>
+                      <string notr="true">TOTP</string>
                      </property>
                     </item>
                     <item>
                      <property name="text">
-                      <string>HOTP</string>
+                      <string notr="true">HOTP</string>
                      </property>
                     </item>
                     <item>
                      <property name="text">
-                      <string>HMAC</string>
+                      <string notr="true">HMAC</string>
                      </property>
                     </item>
                    </widget>

--- a/nitrokeyapp/ui/welcome_tab.ui
+++ b/nitrokeyapp/ui/welcome_tab.ui
@@ -363,6 +363,94 @@
         </widget>
        </item>
        <item>
+        <widget class="QFrame" name="frame_language">
+         <property name="frameShape">
+          <enum>QFrame::Shape::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Raised</enum>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_language">
+          <property name="leftMargin">
+           <number>14</number>
+          </property>
+          <property name="topMargin">
+           <number>12</number>
+          </property>
+          <property name="rightMargin">
+           <number>14</number>
+          </property>
+          <property name="bottomMargin">
+           <number>12</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="LanguageLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Language:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+            <property name="buddy">
+             <cstring>SelectLanguage</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="LanguageHint">
+            <property name="text">
+             <string>Restart to apply</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_language">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QComboBox" name="SelectLanguage">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QFrame" name="frame_help">
          <property name="frameShape">
           <enum>QFrame::Shape::StyledPanel</enum>

--- a/nitrokeyapp/ui_loader.py
+++ b/nitrokeyapp/ui_loader.py
@@ -30,6 +30,8 @@ class UiLoader(QUiLoader):
         """
 
         QUiLoader.__init__(self, baseinstance)
+        self.setTranslationEnabled(True)
+        self.setLanguageChangeEnabled(True)
         self.baseinstance = baseinstance
         self.customWidgets = customWidgets or {}
 

--- a/nitrokeyapp/update.py
+++ b/nitrokeyapp/update.py
@@ -12,6 +12,8 @@ from nitrokey.trussed.admin_app import InitStatus
 from nitrokey.trussed.updates import DeviceHandler, Updater, UpdateUi, Warning
 from PySide6.QtCore import QCoreApplication
 
+from nitrokeyapp.error_messages import warning_message
+
 if TYPE_CHECKING:
     from nitrokeyapp.common_ui import CommonUi
 
@@ -60,20 +62,30 @@ class UpdateGUI(UpdateUi):
         return UpdateException(UpdateStatus.ABORTED, *msgs)
 
     def raise_warning(self, warning: Warning) -> Exception:
-        return UpdateException(UpdateStatus.ERROR, warning.message)
+        return UpdateException(UpdateStatus.ERROR, warning_message(warning))
 
     def show_warning(self, warning: Warning) -> None:
         res = self.run_confirm_dialog(
-            "DANGER - You can ignore this warning by pressing ok", warning.message
+            QCoreApplication.translate(
+                "update", "DANGER - you can ignore this warning by pressing OK"
+            ),
+            warning_message(warning),
         )
         if not res:
             logger.info("Cancel clicked (during warning)")
-            raise self.abort("Warning dialog canceled")
+            raise self.abort(
+                QCoreApplication.translate("update", "The firmware update was cancelled.")
+            )
 
         logger.info("OK clicked (warning dialog)")
 
     def abort_downgrade(self, current: Version, image: Version) -> Exception:
-        return self.abort(f"firmware {image} is older than the firmware on the device ({current})")
+        logger.warning(f"downgrade from {current} to {image}")
+        return self.abort(
+            QCoreApplication.translate(
+                "update", "The firmware image ({0}) is older than the firmware on the device ({1})."
+            ).format(image, current)
+        )
 
     def run_confirm_dialog(self, title: str, desc: str) -> bool:
         self.common_ui.prompt.confirm.emit(title, desc)
@@ -87,53 +99,71 @@ class UpdateGUI(UpdateUi):
 
     def confirm_download(self, current: Version | None, new: Version) -> None:
         res = self.run_confirm_dialog(
-            f"{self.model} Firmware Update", f"Do you want to download the firmware version {new}?"
+            self.update_title(),
+            QCoreApplication.translate(
+                "update", "Do you want to download firmware version {0}?"
+            ).format(new),
         )
         if not res:
             logger.info("Cancel clicked (confirm download)")
-            raise self.abort("Abort: canceled by user (confirm download)")
+            raise self.abort(
+                QCoreApplication.translate("update", "The firmware update was cancelled.")
+            )
 
         logger.info("OK clicked (confirm download)")
 
+    def update_title(self) -> str:
+        return QCoreApplication.translate("update", "{0} Firmware Update").format(self.model)
+
     def confirm_update(self, current: Version | None, new: Version) -> None:
+        warning = QCoreApplication.translate(
+            "update",
+            "Please do not remove the {0} or insert any other {0} devices during the "
+            "update. Doing so may damage the {0}.",
+        ).format(self.model)
+
         if self.is_qubesos:
-            res = self.run_confirm_dialog(
-                f"{self.model} Firmware Update",
-                f"Please do not remove the {self.model} or insert any other "
-                + f"{self.model} devices during the update. Doing so may "
-                + f"damage the {self.model}.\n\n"
-                + "QubesOS is detected!\n\n"
-                + f"After the touch prompt, the {self.model} will be loaded into the bootloader. The Nitrokey must then be reattach to the current Qube.\n\n"
-                + "Do you want to perform the firmware update now?",
+            question = QCoreApplication.translate(
+                "update",
+                "QubesOS is detected!\n\n"
+                "After the touch prompt, the {0} will be loaded into the bootloader. "
+                "The Nitrokey must then be reattached to the current Qube.\n\n"
+                "Do you want to perform the firmware update now?",
+            ).format(self.model)
+        else:
+            question = QCoreApplication.translate(
+                "update", "Do you want to perform the firmware update now?"
             )
 
-        else:
-            res = self.run_confirm_dialog(
-                f"{self.model} Firmware Update",
-                f"Please do not remove the {self.model} or insert any other "
-                + f"{self.model} devices during the update. Doing so may "
-                + f"damage the {self.model}. Do you want to perform the "
-                + "firmware update now?",
-            )
+        res = self.run_confirm_dialog(self.update_title(), f"{warning}\n\n{question}")
         if not res:
             logger.info("Cancel clicked (confirm update)")
-            raise self.abort("canceled by user (confirm update)")
+            raise self.abort(
+                QCoreApplication.translate("update", "The firmware update was cancelled.")
+            )
 
         logger.info("OK clicked (confirm update)")
         self.common_ui.touch.start.emit()
 
     def pre_bootloader_hint(self) -> None:
-        self.common_ui.info.info.emit("Device is in bootloader mode")
+        self.common_ui.info.info.emit(
+            QCoreApplication.translate("update", "Device is in bootloader mode")
+        )
 
     def confirm_update_same_version(self, version: Version) -> None:
         res = self.run_confirm_dialog(
-            f"{self.model} Firmware Update",
-            "The version of the firmware image is the same as on the device."
-            + "Do you want to continue anyway?",
+            self.update_title(),
+            QCoreApplication.translate(
+                "update",
+                "The version of the firmware image is the same as the one on the device. "
+                "Do you want to continue anyway?",
+            ),
         )
         if not res:
             logger.info("Cancel clicked (confirm same version)")
-            raise self.abort("canceled by user (confirm same version)")
+            raise self.abort(
+                QCoreApplication.translate("update", "The firmware update was cancelled.")
+            )
 
         logger.info("OK clicked (confirm same version)")
 
@@ -141,23 +171,41 @@ class UpdateGUI(UpdateUi):
         if len(txt) == 0:
             return
 
-        res = self.run_confirm_dialog("Confirm extra information", " ".join(txt))
+        res = self.run_confirm_dialog(
+            QCoreApplication.translate("update", "Confirm extra information"), " ".join(txt)
+        )
         if not res:
             logger.info("Cancel clicked (confirm extra info)")
-            raise self.abort("canceled by user (confirm extra info)")
+            raise self.abort(
+                QCoreApplication.translate("update", "The firmware update was cancelled.")
+            )
 
-        logger.info("OK clicked (confirm same version)")
+        logger.info("OK clicked (confirm extra info)")
 
     def abort_pynitrokey_version(self, current: Version, required: Version) -> Exception:
-        raise self.abort(f"pynitrokey {required} too old, need: {current}")
+        raise self.abort(self.pynitrokey_version_message(current, required))
 
     def confirm_pynitrokey_version(self, current: Version, required: Version) -> None:
         # TODO: implement
-        raise self.abort(f"pynitrokey {required} too old, need: {current}")
+        raise self.abort(self.pynitrokey_version_message(current, required))
+
+    def pynitrokey_version_message(self, current: Version, required: Version) -> str:
+        logger.error(f"pynitrokey {current} too old, need: {required}")
+        return QCoreApplication.translate(
+            "update",
+            "This version of the Nitrokey App is too old for the update. "
+            "Please install version {0} or newer.",
+        ).format(required)
 
     def request_repeated_update(self) -> Exception:
         logger.info("Bootloader mode enabled. Repeat to update")
-        return self.abort("bootloader enabled")
+        return self.abort(
+            QCoreApplication.translate(
+                "update",
+                "The device was switched to bootloader mode. "
+                "Please start the firmware update again.",
+            )
+        )
 
     def request_bootloader_confirmation(self) -> None:
         logger.info("requesting bootloader confirmation")
@@ -166,17 +214,17 @@ class UpdateGUI(UpdateUi):
     @contextmanager
     def update_progress_bar(self) -> Iterator[Callable[[int, int], None]]:
         self.common_ui.touch.stop.emit()
-        self.common_ui.progress.start.emit("Update")
+        self.common_ui.progress.start.emit(QCoreApplication.translate("update", "Update"))
         yield self.common_ui.progress.progress.emit
 
     @contextmanager
     def download_progress_bar(self, desc: str) -> Iterator[Callable[[int, int], None]]:
-        self.common_ui.progress.start.emit("Download")
+        self.common_ui.progress.start.emit(QCoreApplication.translate("update", "Download"))
         yield self.common_ui.progress.progress.emit
 
     @contextmanager
     def finalization_progress_bar(self) -> Iterator[Callable[[int, int], None]]:
-        self.common_ui.progress.start.emit("Finalization")
+        self.common_ui.progress.start.emit(QCoreApplication.translate("update", "Finalization"))
         yield self.common_ui.progress.progress.emit
 
 
@@ -189,11 +237,18 @@ class UpdateContext(DeviceHandler):
 
     def connect(self) -> TrussedBase:
         device = trussed.open(path=self.path, model=self.model)
-        # TODO: improve error handling
         if not device:
-            raise RuntimeError(f"Failed to open {self.model} device at {self.path}")
+            logger.error(f"failed to open {self.model} device at {self.path}")
+            raise RuntimeError(
+                QCoreApplication.translate("update", "The device is no longer available.")
+            )
         if device.model != self.model:
-            raise RuntimeError(f"Found {device.model} device at {self.path}, expected {self.model}")
+            logger.error(f"found {device.model} at {self.path}, expected {self.model}")
+            raise RuntimeError(
+                QCoreApplication.translate(
+                    "update", "Found a {0} where a {1} was expected."
+                ).format(device.model, self.model)
+            )
         return device
 
     def _await(
@@ -218,12 +273,22 @@ class UpdateContext(DeviceHandler):
                 logger.debug(f"No {name} device found, continuing")
                 continue
             if len(devices) > 1:
-                raise Exception(f"Multiple {name} devices found")
+                logger.error(f"multiple {name} devices found")
+                raise Exception(
+                    QCoreApplication.translate(
+                        "update",
+                        "More than one {0} is connected. Please connect only the device "
+                        "that should be updated.",
+                    ).format(name)
+                )
             if callback:
                 callback(100, 100)
             return devices[0]
 
-        raise Exception(f"No {name} device found")
+        logger.error(f"no {name} device found")
+        raise Exception(
+            QCoreApplication.translate("update", "The {0} could not be found.").format(name)
+        )
 
     def await_device(
         self,
@@ -256,8 +321,11 @@ class UpdateContext(DeviceHandler):
                 return UpdateResult(
                     model=self.model,
                     status=UpdateStatus.ERROR,
-                    message="External filesystem needs to be reformatted."
-                    " Please contact support@nitrokey.com for more information on how to solve this issue.",
+                    message=QCoreApplication.translate(
+                        "update",
+                        "The external filesystem of the device needs to be reformatted. "
+                        "Please contact {0} for more information on how to solve this issue.",
+                    ).format("support@nitrokey.com"),
                 )
 
         return UpdateResult(model=self.model, status=UpdateStatus.SUCCESS)

--- a/nitrokeyapp/utils.py
+++ b/nitrokeyapp/utils.py
@@ -79,8 +79,14 @@ def check_ccid_config(parent: Optional["QWidget"] = None) -> None:
             logger.warning(message)
             sys.stderr.write(f"WARNING: {message}\n")
 
+            from PySide6.QtCore import QCoreApplication
             from PySide6.QtWidgets import QMessageBox
 
             QMessageBox.warning(
-                parent, "Missing Dependency", f"{message}.\nPlease install it to use CCID mode."
+                parent,
+                QCoreApplication.translate("utils", "Missing Dependency"),
+                QCoreApplication.translate(
+                    "utils",
+                    "{0} is set but pyscard is not installed.\nPlease install it to use CCID mode.",
+                ).format(NITROKEY_FORCE_CCID),
             )

--- a/nitrokeyapp/welcome_tab.py
+++ b/nitrokeyapp/welcome_tab.py
@@ -1,13 +1,16 @@
+import logging
 import webbrowser
 
 from nitrokey.trussed import Version
 from nitrokey.updates import Repository
-from PySide6.QtCore import Slot
+from PySide6.QtCore import Qt, Slot
 from PySide6.QtWidgets import QWidget
 
-from nitrokeyapp import __version__
+from nitrokeyapp import __version__, i18n
 from nitrokeyapp.logger import save_log
 from nitrokeyapp.qt_utils_mix_in import QtUtilsMixIn
+
+logger = logging.getLogger(__name__)
 
 REPOSITORY_OWNER = "Nitrokey"
 REPOSITORY_NAME = "nitrokey-app2"
@@ -27,6 +30,58 @@ class WelcomeTab(QtUtilsMixIn, QWidget):
         self.ui.buttonSaveLog.pressed.connect(self.save_log)
         self.ui.VersionNr.setText(__version__)
         self.ui.CheckUpdate.pressed.connect(self.check_update)
+        self.init_language_selection()
+
+    def init_language_selection(self) -> None:
+        """Fill the language selector and remember what the user picks.
+
+        A change only takes effect on the next start, which the hint next to the
+        selector says once something was actually changed.
+        """
+        combo = self.ui.SelectLanguage
+        self.ui.LanguageHint.hide()
+
+        forced = i18n.forced_language()
+        # what the application is running in, to tell a real change from a no-op
+        self.active_language = i18n.resolved_language()
+
+        self.selected_language = forced or i18n.stored_language()
+        languages = [i18n.SYSTEM_LANGUAGE, *i18n.available_languages()]
+        if self.selected_language not in languages:
+            if forced is not None:
+                # NKAPP_LANG may name a language whose catalog holds nothing yet
+                languages.append(self.selected_language)
+            else:
+                logger.warning(f"no catalog for the selected language {self.selected_language!r}")
+                self.selected_language = i18n.SYSTEM_LANGUAGE
+
+        if len(languages) < 3 and forced is None:
+            logger.info("no translations installed, hiding the language selector")
+            self.ui.frame_language.hide()
+            return
+
+        for language in languages:
+            combo.addItem(i18n.language_name(language), language)
+        combo.setCurrentIndex(combo.findData(self.selected_language))
+
+        if forced is not None:
+            combo.setEnabled(False)
+            combo.setToolTip(
+                self.tr("The language is set to {0} by {1}.").format(forced, i18n.NKAPP_LANG)
+            )
+            return
+
+        combo.currentIndexChanged.connect(self.language_selected)
+
+    @Slot(int)
+    def language_selected(self, index: int) -> None:
+        if index < 0:
+            return
+        language = self.ui.SelectLanguage.itemData(index, Qt.ItemDataRole.UserRole)
+        i18n.set_configured_language(language)
+        # "System language" and the language it resolves to are the same choice,
+        # so compare what the next start would use
+        self.ui.LanguageHint.setVisible(i18n.resolved_language() != self.active_language)
 
     def refresh_icons(self) -> None:
         """re-resolve all themed icons, e.g. after a light/dark mode switch"""
@@ -36,19 +91,19 @@ class WelcomeTab(QtUtilsMixIn, QWidget):
         try:
             release = REPOSITORY.get_latest_release()
         except Exception:
-            self.ui.CheckUpdate.setText("No connection")
+            self.ui.CheckUpdate.setText(self.tr("No connection"))
             return
 
         current = Version.from_str(__version__)
         latest = Version.from_v_str(release.tag)
 
         if current < latest:
-            self.ui.CheckUpdate.setText("update available")
+            self.ui.CheckUpdate.setText(self.tr("Update available"))
             self.ui.CheckUpdate.pressed.connect(
                 lambda: webbrowser.open("https://github.com/Nitrokey/nitrokey-app2/releases")
             )
         else:
-            self.ui.CheckUpdate.setText("App is up to date")
+            self.ui.CheckUpdate.setText(self.tr("App is up to date"))
 
     @Slot()
     def save_log(self) -> None:

--- a/nitrokeyapp/worker.py
+++ b/nitrokeyapp/worker.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from PySide6.QtCore import QObject, Signal, Slot
 
 from nitrokeyapp.common_ui import CommonUi
+from nitrokeyapp.error_messages import user_message
 
 logger = logging.getLogger(__name__)
 
@@ -34,14 +35,14 @@ class Job(QObject):
     @Slot(str)
     def trigger_error(self, msg: str) -> None:
         logger.error(f"{self.__class__.__name__} failed: {msg}")
-        self.common_ui.info.error.emit(f"{self.__class__.__name__}: {msg}")
+        self.common_ui.info.error.emit(msg)
         self.failed.emit()
         self.finished.emit()
 
     @Slot(Exception)
     def trigger_exception(self, exc: Exception) -> None:
         logger.error(f"{self.__class__.__name__} raised: {exc}", exc_info=exc)
-        self.common_ui.info.error.emit(f"{self.__class__.__name__}: {exc}")
+        self.common_ui.info.error.emit(user_message(exc))
         self.failed.emit()
         self.finished.emit()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
 ]
+# the compiled catalogs are build artifacts, `make build` compiles them first
+include = [
+  { path = "nitrokeyapp/translations/*.qm", format = ["sdist", "wheel"] },
+]
 
 [tool.poetry.dependencies]
 click = "^8"


### PR DESCRIPTION
- .ts catalogs, edited in Qt Linguist, compiled to .qm at build time
- covers the .ui files too, which load at runtime and never go through pyside6-uic
- the language is picked before the first widget is built, and can be set on the start page
- device errors are mapped from their status codes and error enums (reword in the SDK does not drop a translation)
- German included

- boxes now draw a drop-down indicator (was missing before)
