### PR TITLE
Make every job finish exactly once

### DIFF
--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -393,6 +393,7 @@ class AddCredentialJob(Job):
 
             if self.credential.uri and self.credential.id:
                 self.trigger_error("Other fields must be empty if URI is used")
+                return
 
             secrets = SecretsApp(device)
             with self.touch_prompt():
@@ -535,6 +536,7 @@ class GenerateOtpJob(Job):
                 validity = (valid_from, valid_until)
             else:
                 self.trigger_exception(RuntimeError(f"Unexpected OTP kind: {self.credential.otp}"))
+                return
 
             try:
                 with self.touch_prompt():

--- a/nitrokeyapp/secrets_tab/worker.py
+++ b/nitrokeyapp/secrets_tab/worker.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import QWidget
 
 from nitrokeyapp.common_ui import CommonUi
 from nitrokeyapp.device_data import DeviceData
-from nitrokeyapp.worker import Job, Worker
+from nitrokeyapp.worker import Job, Worker, guarded_slot
 
 from .data import Credential, OtpData, OtpKind
 from .ui import PinUi
@@ -136,7 +136,7 @@ class VerifyPinJob(Job):
         else:
             self.pin_verified.emit(False)
 
-    @Slot(str)
+    @guarded_slot(str)
     def pin_queried(self, pin: str) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
@@ -154,7 +154,7 @@ class VerifyPinJob(Job):
                 # TODO: repeat on failure
                 self.trigger_error("Incorrect PIN. Please try again.")
 
-    @Slot(str)
+    @guarded_slot(str)
     def pin_chosen(self, pin: str) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
@@ -210,7 +210,7 @@ class EditCredentialJob(Job):
         list_credentials_job.credentials_listed.connect(self.check_credential)
         self.spawn(list_credentials_job)
 
-    @Slot(list)
+    @guarded_slot(list)
     def check_credential(self, credentials: list[Credential]) -> None:
         self.all_credentials = {cred.id: cred for cred in credentials}
         # ids = set([credential.id for credential in credentials])
@@ -236,7 +236,7 @@ class EditCredentialJob(Job):
         else:
             self.edit_credential()
 
-    @Slot()
+    @guarded_slot()
     def edit_credential(self, successful: bool = True) -> None:
         if not successful:
             self.finished.emit()
@@ -264,6 +264,7 @@ class EditCredentialJob(Job):
         add_job.credential_added.connect(lambda cred: self.handle_created(cred, then_delete_id))
         self.spawn(add_job)
 
+    @guarded_slot(Credential, bytes)
     def handle_created(self, credential: Credential, delete_id: bytes) -> None:
         self.credential = credential
         self.delete_credential(delete_id)
@@ -280,7 +281,7 @@ class EditCredentialJob(Job):
         del_job.credential_deleted.connect(self.handle_deleted)
         self.spawn(del_job)
 
-    @Slot(Credential)
+    @guarded_slot(Credential)
     def handle_deleted(self, credential: Credential) -> None:
         # drop credential
         self.credential_edited.emit(self.credential)
@@ -300,7 +301,7 @@ class EditCredentialJob(Job):
 
         return new_cred_id
 
-    @Slot()
+    @guarded_slot()
     def edit_credential_final(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
@@ -361,7 +362,7 @@ class AddCredentialJob(Job):
         list_credentials_job.credentials_listed.connect(self.check_credential)
         self.spawn(list_credentials_job)
 
-    @Slot(list)
+    @guarded_slot(list)
     def check_credential(self, credentials: list[Credential]) -> None:
         ids = {credential.id for credential in credentials}
         if self.credential.id in ids:
@@ -379,7 +380,7 @@ class AddCredentialJob(Job):
         else:
             self.add_credential(True)
 
-    @Slot(bool)
+    @guarded_slot(bool)
     def add_credential(self, successful: bool = True) -> None:
         if not successful:
             self.finished.emit()
@@ -467,7 +468,7 @@ class DeleteCredentialJob(Job):
             else:
                 self.delete_credential()
 
-    @Slot()
+    @guarded_slot()
     def delete_credential(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
@@ -513,7 +514,7 @@ class GenerateOtpJob(Job):
         else:
             self.generate_otp()
 
-    @Slot()
+    @guarded_slot()
     def generate_otp(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
@@ -580,7 +581,7 @@ class ListCredentialsJob(Job):
                 credentials = Credential.list(secrets)
             self.credentials_listed.emit(credentials)
 
-    @Slot(bool)
+    @guarded_slot(bool)
     def list_protected_credentials(self, successful: bool) -> None:
         credentials = []
         if not successful:
@@ -628,7 +629,7 @@ class GetCredentialJob(Job):
             else:
                 self.get_credential()
 
-    @Slot()
+    @guarded_slot()
     def get_credential(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
@@ -685,10 +686,11 @@ class BackupCredentialJob(Job):
             list(status.skipped_credentials),
         )
 
-    @Slot()
+    @guarded_slot()
     def get_credential_backup(self) -> None:
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             pin = self.pin_cache.get(self.data) or ""
@@ -745,7 +747,7 @@ class RestoreCredentialJob(Job):
             list(status.skipped_credentials),
         )
 
-    @Slot(bool)
+    @guarded_slot(bool)
     def restore_credential_backup(self, successful: bool) -> None:
         if not successful:
             self.credential_restore.emit()
@@ -759,6 +761,7 @@ class RestoreCredentialJob(Job):
 
         with self.data.open() as device:
             if not isinstance(device, NK3):
+                self.trigger_error("This device does not support Passwords")
                 return
             secrets = SecretsApp(device)
             pin = self.pin_cache.get(self.data) or ""

--- a/nitrokeyapp/settings_tab/worker.py
+++ b/nitrokeyapp/settings_tab/worker.py
@@ -94,6 +94,7 @@ class SaveFidoPinJob(Job):
                     self.common_ui.info.info.emit("FIDO2 PIN changed!")
             except Exception as e:
                 self.trigger_error(f"fido2 change_pin failed: {e}")
+                return
         self.change_pw_fido.emit()
 
 
@@ -171,6 +172,7 @@ class ResetFido(Job):
                     )
                 else:
                     self.trigger_error(f"fido2 reset failed: {e}")
+                    return
         self.reset_fido.emit()
 
 
@@ -196,6 +198,7 @@ class ResetPasswords(Job):
                     self.common_ui.info.info.emit("PASSWORDS function reset successfully!")
             except SecretsAppException as e:
                 self.trigger_error(f"Passwords reset failed: {e}")
+                return
         self.reset_passwords.emit()
 
 

--- a/nitrokeyapp/worker.py
+++ b/nitrokeyapp/worker.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from functools import wraps
 from typing import Any, TypeVar, cast
 
-from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtCore import QObject, Qt, Signal, Slot
 
 from nitrokeyapp.common_ui import CommonUi
 
@@ -117,5 +117,7 @@ class Worker(QObject):
         logger.info(f"{self.__class__.__name__} starting {job.__class__.__name__}")
         self.busy_state_changed.emit(True)
 
-        job.finished.connect(lambda: self.busy_state_changed.emit(False))
+        job.finished.connect(
+            lambda: self.busy_state_changed.emit(False), Qt.ConnectionType.SingleShotConnection
+        )
         job.run_guarded()

--- a/nitrokeyapp/worker.py
+++ b/nitrokeyapp/worker.py
@@ -1,12 +1,47 @@
+import inspect
 import logging
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
+from functools import wraps
+from typing import Any, TypeVar, cast
 
 from PySide6.QtCore import QObject, Signal, Slot
 
 from nitrokeyapp.common_ui import CommonUi
 
 logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+POSITIONAL_KINDS = (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+
+
+def guarded_slot(*types: Any) -> Callable[[F], F]:
+    """Slot decorator for job continuations.
+
+    Qt calls a continuation straight from the event loop, so an exception in one
+    would not be seen by Job.run_guarded. The job would never emit finished and
+    the UI would stay busy until the app is restarted. Report the exception
+    through the job instead, so it always ends with failed and finished.
+    """
+
+    def decorator(method: F) -> F:
+        params = list(inspect.signature(method).parameters.values())
+        positional = [p for p in params if p.kind in POSITIONAL_KINDS]
+        takes_varargs = any(p.kind is p.VAR_POSITIONAL for p in params)
+        limit = None if takes_varargs else len(positional) - 1
+
+        @wraps(method)
+        def wrapper(self: "Job", *args: Any, **kwargs: Any) -> None:
+            try:
+                method(self, *args[:limit], **kwargs)
+            except Exception as e:
+                self.trigger_exception(e)
+
+        return cast(F, Slot(*types)(wrapper))
+
+    return decorator
+
 
 # TODO: DeviceJob
 # - connection management
@@ -26,6 +61,13 @@ class Job(QObject):
 
     def run(self) -> None:
         pass
+
+    def run_guarded(self) -> None:
+        """Run the job, ending it with an error instead of letting exceptions escape."""
+        try:
+            self.run()
+        except Exception as e:
+            self.trigger_exception(e)
 
     @Slot()
     def cleanup(self) -> None:
@@ -47,7 +89,7 @@ class Job(QObject):
 
     def spawn(self, job: "Job") -> None:
         job.failed.connect(self.propagate_failure)
-        job.run()
+        job.run_guarded()
 
     @Slot()
     def propagate_failure(self) -> None:
@@ -76,7 +118,4 @@ class Worker(QObject):
         self.busy_state_changed.emit(True)
 
         job.finished.connect(lambda: self.busy_state_changed.emit(False))
-        try:
-            job.run()
-        except Exception as e:
-            job.trigger_exception(e)
+        job.run_guarded()


### PR DESCRIPTION
- add `guarded_slot`, a `@Slot` that sends exceptions to `Job.trigger_exception`, and use it for the 15 continuations in the Passwords tab
- move the try/except in `Worker.run` into `Job.run_guarded` so `Job.spawn` is covered too
- report an error at the two backup/restore bail-outs that returned silently
- return after reporting an error in AddCredentialJob, GenerateOtpJob, SaveFidoPinJob, ResetFido and ResetPasswords
- count the busy state down once per job with `Qt.SingleShotConnection`
